### PR TITLE
Improve web3-subprovider with getTransport param

### DIFF
--- a/packages/create-dapp/template/package.json
+++ b/packages/create-dapp/template/package.json
@@ -7,7 +7,8 @@
     "react-dom": "^16.2.0",
     "react-scripts": "1.1.0",
     "truffle-contract": "^3.0.3",
-    "@ledgerhq/web3-subprovider": "^3.0.0",
+    "@ledgerhq/web3-subprovider": "^4.0.0",
+    "@ledgerhq/hw-transport-u2f": "^4.0.0",
     "web3": "^1.0.0-beta.29"
   },
   "scripts": {

--- a/packages/create-dapp/template/src/wallets.js
+++ b/packages/create-dapp/template/src/wallets.js
@@ -1,5 +1,6 @@
 // @flow
 import Web3 from "web3";
+import TransportU2F from "@ledgerhq/hw-transport-u2f";
 import createLedgerSubprovider from "@ledgerhq/web3-subprovider";
 import ProviderEngine from "web3-provider-engine";
 import FetchSubprovider from "web3-provider-engine/subproviders/fetch";
@@ -23,7 +24,8 @@ export default [
     // create a web3 with the ledger device
     getWeb3: async () => {
       const engine = new ProviderEngine();
-      const ledger = await createLedgerSubprovider({
+      const getTransport = () => TransportU2F.create();
+      const ledger = await createLedgerSubprovider(getTransport, {
         networkId,
         accountsLength: 5
       });

--- a/packages/web3-subprovider/src/index.js
+++ b/packages/web3-subprovider/src/index.js
@@ -1,19 +1,25 @@
 //@flow
 import AppEth from "@ledgerhq/hw-app-eth";
-import TransportU2F from "@ledgerhq/hw-transport-u2f";
-import { TransportError } from "@ledgerhq/hw-transport";
+import type Transport from "@ledgerhq/hw-transport";
 import HookedWalletSubprovider from "web3-provider-engine/subproviders/hooked-wallet";
 import stripHexPrefix from "strip-hex-prefix";
 import EthereumTx from "ethereumjs-tx";
 
 const allowedHdPaths = ["44'/60'", "44'/61'"];
 
+function makeError(msg, id) {
+  const err = new Error(msg);
+  // $FlowFixMe
+  err.id = id;
+  return err;
+}
+
 function obtainPathComponentsFromDerivationPath(derivationPath) {
   // check if derivation path follows 44'/60'/x'/n pattern
   const regExp = /^(44'\/6[0|1]'\/\d+'?\/)(\d+)$/;
   const matchResult = regExp.exec(derivationPath);
   if (matchResult === null) {
-    throw new TransportError(
+    throw makeError(
       "To get multiple accounts your derivation path must follow pattern 44'/60|61'/x'/n ",
       "InvalidDerivationPath"
     );
@@ -33,9 +39,7 @@ type SubproviderOptions = {
   // number of accounts to derivate
   accountsLength?: number,
   // offset index to use to start derivating the accounts
-  accountsOffset?: number,
-  // timeout to wait the device
-  timeout?: number
+  accountsOffset?: number
 };
 
 const defaultOptions = {
@@ -48,13 +52,16 @@ const defaultOptions = {
 
 /**
  * Create a HookedWalletSubprovider for Ledger devices.
+ * @param getTransport gets lazily called each time the device is needed. It is a function that returns a Transport instance. You can typically give `()=>TransportU2F.create()`
  * @example
 import Web3 from "web3";
 import createLedgerSubprovider from "@ledgerhq/web3-subprovider";
+import TransportU2F from "@ledgerhq/hw-transport-u2f";
 import ProviderEngine from "web3-provider-engine";
 import RpcSubprovider from "web3-provider-engine/subproviders/rpc";
 const engine = new ProviderEngine();
-const ledger = await createLedgerSubprovider({
+const getTransport = () => TransportU2F.create();
+const ledger = createLedgerSubprovider(getTransport, {
   accountsLength: 5
 });
 engine.addProvider(ledger);
@@ -62,24 +69,16 @@ engine.addProvider(new RpcSubprovider({ rpcUrl }));
 engine.start();
 const web3 = new Web3(engine);
  */
-// TODO in next major, we'll make createLedgerSubprovider take a transport instance as first argument
-// as we don't want to depends on U2F and move the transport creation logic on user land
 export default async function createLedgerSubprovider(
+  getTransport: () => Transport<*>,
   options?: SubproviderOptions
-): Promise<HookedWalletSubprovider> {
-  const {
-    networkId,
-    path,
-    askConfirm,
-    accountsLength,
-    accountsOffset,
-    timeout
-  } = {
+): HookedWalletSubprovider {
+  const { networkId, path, askConfirm, accountsLength, accountsOffset } = {
     ...defaultOptions,
     ...options
   };
   if (!allowedHdPaths.some(hdPref => path.startsWith(hdPref))) {
-    throw new TransportError(
+    throw makeError(
       "Ledger derivation path allowed are " +
         allowedHdPaths.join(", ") +
         ". " +
@@ -88,81 +87,91 @@ export default async function createLedgerSubprovider(
       "InvalidDerivationPath"
     );
   }
-  const supported = await TransportU2F.isSupported();
-  if (!supported)
-    throw new TransportError(
-      "U2F is not supported by your browser",
-      "U2FNotSupported"
-    );
-  const transport = await TransportU2F.create(timeout);
-  const eth = new AppEth(transport);
 
   const pathComponents = obtainPathComponentsFromDerivationPath(path);
 
   const addressToPathMap = {};
 
   async function getAccounts() {
-    const addresses = {};
-    for (let i = accountsOffset; i < accountsOffset + accountsLength; i++) {
-      const path =
-        pathComponents.basePath + (pathComponents.index + i).toString();
-      const address = await eth.getAddress(path, askConfirm, false);
-      addresses[path] = address.address;
-      addressToPathMap[address.address] = path;
+    const transport = await getTransport();
+    try {
+      const eth = new AppEth(transport);
+      const addresses = {};
+      for (let i = accountsOffset; i < accountsOffset + accountsLength; i++) {
+        const path =
+          pathComponents.basePath + (pathComponents.index + i).toString();
+        const address = await eth.getAddress(path, askConfirm, false);
+        addresses[path] = address.address;
+        addressToPathMap[address.address] = path;
+      }
+      return addresses;
+    } finally {
+      transport.close();
     }
-    return addresses;
   }
 
   async function signPersonalMessage(msgData) {
     const path = addressToPathMap[msgData.from];
     if (!path) throw new Error("address unknown '" + msgData.from + "'");
-    const result = await eth.signPersonalMessage(
-      path,
-      stripHexPrefix(msgData.data)
-    );
-    const v = parseInt(result.v, 10) - 27;
-    let vHex = v.toString(16);
-    if (vHex.length < 2) {
-      vHex = `0${v}`;
+    const transport = await getTransport();
+    try {
+      const eth = new AppEth(transport);
+      const result = await eth.signPersonalMessage(
+        path,
+        stripHexPrefix(msgData.data)
+      );
+      const v = parseInt(result.v, 10) - 27;
+      let vHex = v.toString(16);
+      if (vHex.length < 2) {
+        vHex = `0${v}`;
+      }
+      return `0x${result.r}${result.s}${vHex}`;
+    } finally {
+      transport.close();
     }
-    return `0x${result.r}${result.s}${vHex}`;
   }
 
   async function signTransaction(txData) {
     const path = addressToPathMap[txData.from];
     if (!path) throw new Error("address unknown '" + txData.from + "'");
-    const tx = new EthereumTx(txData);
+    const transport = await getTransport();
+    try {
+      const eth = new AppEth(transport);
+      const tx = new EthereumTx(txData);
 
-    // Set the EIP155 bits
-    tx.raw[6] = Buffer.from([networkId]); // v
-    tx.raw[7] = Buffer.from([]); // r
-    tx.raw[8] = Buffer.from([]); // s
+      // Set the EIP155 bits
+      tx.raw[6] = Buffer.from([networkId]); // v
+      tx.raw[7] = Buffer.from([]); // r
+      tx.raw[8] = Buffer.from([]); // s
 
-    // Pass hex-rlp to ledger for signing
-    const result = await eth.signTransaction(
-      path,
-      tx.serialize().toString("hex")
-    );
-
-    // Store signature in transaction
-    tx.v = Buffer.from(result.v, "hex");
-    tx.r = Buffer.from(result.r, "hex");
-    tx.s = Buffer.from(result.s, "hex");
-
-    // EIP155: v should be chain_id * 2 + {35, 36}
-    const signedChainId = Math.floor((tx.v[0] - 35) / 2);
-    const validChainId = networkId & 0xff; // FIXME this is to fixed a current workaround that app don't support > 0xff
-    if (signedChainId !== validChainId) {
-      throw new TransportError(
-        "Invalid networkId signature returned. Expected: " +
-          networkId +
-          ", Got: " +
-          signedChainId,
-        "InvalidNetworkId"
+      // Pass hex-rlp to ledger for signing
+      const result = await eth.signTransaction(
+        path,
+        tx.serialize().toString("hex")
       );
-    }
 
-    return `0x${tx.serialize().toString("hex")}`;
+      // Store signature in transaction
+      tx.v = Buffer.from(result.v, "hex");
+      tx.r = Buffer.from(result.r, "hex");
+      tx.s = Buffer.from(result.s, "hex");
+
+      // EIP155: v should be chain_id * 2 + {35, 36}
+      const signedChainId = Math.floor((tx.v[0] - 35) / 2);
+      const validChainId = networkId & 0xff; // FIXME this is to fixed a current workaround that app don't support > 0xff
+      if (signedChainId !== validChainId) {
+        throw makeError(
+          "Invalid networkId signature returned. Expected: " +
+            networkId +
+            ", Got: " +
+            signedChainId,
+          "InvalidNetworkId"
+        );
+      }
+
+      return `0x${tx.serialize().toString("hex")}`;
+    } finally {
+      transport.close();
+    }
   }
 
   const subprovider = new HookedWalletSubprovider({


### PR DESCRIPTION
getTransport also gets called lazily at each time web3 needs to access accounts / sign a transaction.

NB this PR is a breaking change & except a major version bump to be released after merged.