### PR TITLE
Add a lock on a transport

### DIFF
--- a/packages/hw-app-eth/src/Eth.js
+++ b/packages/hw-app-eth/src/Eth.js
@@ -32,7 +32,11 @@ export default class Eth {
 
   constructor(transport: Transport<*>) {
     this.transport = transport;
-    transport.setScrambleKey("w0w");
+    transport.decorateAppAPIMethods(
+      this,
+      ["getAddress", "signTransaction", "signPersonalMessage"],
+      "w0w"
+    );
   }
 
   /**

--- a/packages/hw-app-str/src/Str.js
+++ b/packages/hw-app-str/src/Str.js
@@ -54,7 +54,11 @@ export default class Str {
 
   constructor(transport: Transport<*>) {
     this.transport = transport;
-    transport.setScrambleKey("l0v");
+    transport.decorateAppAPIMethods(
+      this,
+      ["getAppConfiguration", "getPublicKey", "signTransaction", "signHash"],
+      "l0v"
+    );
   }
 
   getAppConfiguration(): Promise<{
@@ -186,7 +190,7 @@ export default class Str {
         };
       } else if (status === SW_UNKNOWN_OP) {
         // pre-v2 app version: fall back on hash signing
-        return this.signHash(path, hash(transaction));
+        return this.signHash_private(path, hash(transaction));
       } else {
         throw new Error("Transaction approval request was rejected");
       }
@@ -203,6 +207,10 @@ export default class Str {
    * str.signHash("44'/148'/0'", hash).then(o => o.signature)
    */
   signHash(path: string, hash: Buffer): Promise<{ signature: Buffer }> {
+    return this.signHash_private(path, hash);
+  }
+
+  signHash_private(path: string, hash: Buffer): Promise<{ signature: Buffer }> {
     let pathElts = splitPath(path);
     let buffer = Buffer.alloc(1 + pathElts.length * 4);
     buffer[0] = pathElts.length;

--- a/packages/hw-app-xrp/src/Xrp.js
+++ b/packages/hw-app-xrp/src/Xrp.js
@@ -15,7 +15,11 @@ export default class Xrp {
 
   constructor(transport: Transport<*>) {
     this.transport = transport;
-    transport.setScrambleKey("w0w");
+    transport.decorateAppAPIMethods(
+      this,
+      ["getAddress", "signTransaction", "getAppConfiguration"],
+      "w0w"
+    );
   }
 
   /**

--- a/packages/hw-transport/src/Transport.js
+++ b/packages/hw-transport/src/Transport.js
@@ -284,6 +284,52 @@ TransportFoo.create().then(transport => ...)
     });
   }
 
+  decorateAppAPIMethods(
+    self: Object,
+    methods: Array<string>,
+    scrambleKey: string
+  ) {
+    for (let methodName of methods) {
+      self[methodName] = this.decorateAppAPIMethod(
+        methodName,
+        self[methodName],
+        self,
+        scrambleKey
+      );
+    }
+  }
+
+  _appAPIlock = null;
+  decorateAppAPIMethod<R, A: any[]>(
+    methodName: string,
+    f: (...args: A) => Promise<R>,
+    ctx: *,
+    scrambleKey: string
+  ): (...args: A) => Promise<R> {
+    return async (...args) => {
+      const { _appAPIlock } = this;
+      if (_appAPIlock) {
+        const e = new TransportError(
+          "Ledger Device is busy (lock " + _appAPIlock + ")",
+          "TransportLocked"
+        );
+        //$FlowFixMe
+        Object.assign(e, {
+          currentLock: _appAPIlock,
+          methodName
+        });
+        return Promise.reject(e);
+      }
+      try {
+        this._appAPIlock = methodName;
+        this.setScrambleKey(scrambleKey);
+        return await f.apply(ctx, args);
+      } finally {
+        this._appAPIlock = null;
+      }
+    };
+  }
+
   static ErrorMessage_ListenTimeout = "No Ledger device found (timeout)";
   static ErrorMessage_NoDeviceFound = "No Ledger device found";
 }


### PR DESCRIPTION
please review and test carefully.
this intend to fixes https://github.com/LedgerHQ/ledgerjs/issues/83 , race condition when calling multiple times methods, like for instance signing 2 transactions in parallel.

this also fixes https://github.com/LedgerHQ/ledgerjs/issues/97 , allowing multiple apps possible to be instanciated on the same transport.

when you try to call something that is "lock protected" when another thing is running (let's say signMessage is running), it will throw an exception `"Ledger Device is busy (lock signMessage)"`.

@sgehrman would you mind checking if this fixed it for you? I have released version `4.3.0-beta.d226ed3b` of each individual library on NPM that includes this PR changes.


```
Successfully published:
 - @ledgerhq/common@4.3.0-beta.d226ed3b
 - create-dapp@4.3.0-beta.d226ed3b
 - @ledgerhq/currencies@4.3.0-beta.d226ed3b
 - @ledgerhq/hw-app-btc@4.3.0-beta.d226ed3b
 - @ledgerhq/hw-app-eth@4.3.0-beta.d226ed3b
 - @ledgerhq/hw-app-str@4.3.0-beta.d226ed3b
 - @ledgerhq/hw-app-xrp@4.3.0-beta.d226ed3b
 - @ledgerhq/hw-hid-cli@4.3.0-beta.d226ed3b
 - @ledgerhq/hw-http-proxy-devserver@4.3.0-beta.d226ed3b
 - @ledgerhq/hw-transport-http@4.3.0-beta.d226ed3b
 - @ledgerhq/hw-transport-mocker@4.3.0-beta.d226ed3b
 - @ledgerhq/hw-transport-node-hid@4.3.0-beta.d226ed3b
 - @ledgerhq/hw-transport-u2f@4.3.0-beta.d226ed3b
 - @ledgerhq/hw-transport@4.3.0-beta.d226ed3b
 - @ledgerhq/react-native-hid@4.3.0-beta.d226ed3b
 - @ledgerhq/react-native-hw-transport-ble@4.3.0-beta.d226ed3b
 - @ledgerhq/web3-subprovider@4.3.0-beta.d226ed3b
```


thanks