### PR TITLE
Change numeral format in formatShort

### DIFF
--- a/packages/currencies/src/formatShort.js
+++ b/packages/currencies/src/formatShort.js
@@ -9,5 +9,5 @@ import numeral from "numeral";
 export function formatShort(unit: Unit, value: number): string {
   const { magnitude } = unit;
   const floatValue = value / 10 ** magnitude;
-  return numeral(floatValue).format("0.0a");
+  return numeral(floatValue).format("0[.]0a");
 }


### PR DESCRIPTION
Before:

```
numeral(500).format('0.0a')
"500.0"

numeral(1000).format('0.0a')
"1.0k"

numeral(1500).format('0.0a')
"1.5k"
```

After:

```
numeral(500).format('0[.]0a')
"500"

numeral(1000).format('0[.]0a')
"1k"

numeral(1500).format('0[.]0a')
"1.5k"
```