### PR TITLE
Report multi-operation support in Stellar app via getConfiguration

### DIFF
--- a/packages/hw-app-str/src/Str.js
+++ b/packages/hw-app-str/src/Str.js
@@ -68,7 +68,7 @@ export default class Str {
     version: string
   }> {
     return this.transport.send(CLA, INS_GET_CONF, 0x00, 0x00).then(response => {
-      let multiOpsEnabled = response[0] || response[1] < 0x02;
+      let multiOpsEnabled = response[0] === 0x01 || response[1] < 0x02;
       let version = "" + response[1] + "." + response[2] + "." + response[3];
       return {
         version: version,

--- a/packages/hw-app-str/src/Str.js
+++ b/packages/hw-app-str/src/Str.js
@@ -68,9 +68,11 @@ export default class Str {
     version: string
   }> {
     return this.transport.send(CLA, INS_GET_CONF, 0x00, 0x00).then(response => {
+      let multiOpsEnabled = response[0] || response[1] < 0x02;
       let version = "" + response[1] + "." + response[2] + "." + response[3];
       return {
-        version: version
+        version: version,
+        multiOpsEnabled: multiOpsEnabled
       };
     });
   }


### PR DESCRIPTION
In the Stellar app a setting was added to enable/disable support for multi-operation transactions.