### PR TITLE
Disabling device pinging in U2f

### DIFF
--- a/packages/hw-transport-u2f/src/TransportU2F.js
+++ b/packages/hw-transport-u2f/src/TransportU2F.js
@@ -120,8 +120,8 @@ export default class TransportU2F extends Transport<null> {
   /**
    * static function to create a new Transport from a connected Ledger device discoverable via U2F (browser support)
    */
-  static async open(_: *, openTimeout?: number = 5000): Promise<TransportU2F> {
-    try {
+  static async open(_: *, _openTimeout?: number = 5000): Promise<TransportU2F> {
+    /*try {
       // This is not a valid exchange at all, but this allows to have a way to know if there is a device.
       // in case it reaches the timeout, we will throw timeout error, in other case, we will return the U2FTransport.
       await attemptExchange(
@@ -150,7 +150,7 @@ export default class TransportU2F extends Transport<null> {
       } else {
         throw e;
       }
-    }
+    }*/
     return new TransportU2F();
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -937,7 +937,7 @@ async-eventemitter@^0.2.2:
   dependencies:
     async "^2.4.0"
 
-"async-eventemitter@github:ahultgren/async-eventemitter#fa06e39e56786ba541c180061dbf2c0a5bbf951c":
+async-eventemitter@ahultgren/async-eventemitter#fa06e39e56786ba541c180061dbf2c0a5bbf951c:
   version "0.2.3"
   resolved "https://codeload.github.com/ahultgren/async-eventemitter/tar.gz/fa06e39e56786ba541c180061dbf2c0a5bbf951c"
   dependencies:


### PR DESCRIPTION
Allow usage of post 1.4.1 firmware apps with U2F by temporarily disabling device pinging on opening new U2F Transport 