### PR TITLE
web3-subprovider: fix `address unknown error` due to address capitalization

### DIFF
--- a/packages/web3-subprovider/src/index.js
+++ b/packages/web3-subprovider/src/index.js
@@ -102,7 +102,7 @@ export default function createLedgerSubprovider(
           pathComponents.basePath + (pathComponents.index + i).toString();
         const address = await eth.getAddress(path, askConfirm, false);
         addresses[path] = address.address;
-        addressToPathMap[address.address] = path;
+        addressToPathMap[address.address.toLowerCase()] = path;
       }
       return addresses;
     } finally {
@@ -111,7 +111,7 @@ export default function createLedgerSubprovider(
   }
 
   async function signPersonalMessage(msgData) {
-    const path = addressToPathMap[msgData.from];
+    const path = addressToPathMap[msgData.from.toLowerCase()];
     if (!path) throw new Error("address unknown '" + msgData.from + "'");
     const transport = await getTransport();
     try {
@@ -132,7 +132,7 @@ export default function createLedgerSubprovider(
   }
 
   async function signTransaction(txData) {
-    const path = addressToPathMap[txData.from];
+    const path = addressToPathMap[txData.from.toLowerCase()];
     if (!path) throw new Error("address unknown '" + txData.from + "'");
     const transport = await getTransport();
     try {


### PR DESCRIPTION
in `"web3": "^1.0.0-beta.28"`, when calling `web3.eth.personal.sign`, the payload address will be casted to lower case by input address formatter
https://github.com/ethereum/web3.js/blob/1.0/packages/web3-core-helpers/src/formatters.js#L396

however the `addressToPathMap` is storing the `capitalization checksum address` as key, thus the lower case address mismatch and the sign fail.

This PR fixes this by casting all input addresses and `addressToPathMap` keys to lower case