### PR TITLE
currencies: add chopCurrencyUnitDecimals

### DIFF
--- a/packages/currencies/src/chopCurrencyUnitDecimals.js
+++ b/packages/currencies/src/chopCurrencyUnitDecimals.js
@@ -1,0 +1,37 @@
+//@flow
+import type { Unit } from "./types";
+import { getSeparators } from "./parseCurrencyUnit";
+
+const defaultFormatOptions = {
+  locale: "en-EN"
+};
+
+// remove the extra decimals that can't be represented in unit
+// this function will preserve the string characters
+// for instance EUR 1,230.00234 will be transformed to EUR 1,230.00
+export const chopCurrencyUnitDecimals = (
+  unit: Unit,
+  valueString: string,
+  options?: $Shape<typeof defaultFormatOptions>
+): string => {
+  const { locale } = {
+    ...defaultFormatOptions,
+    ...options
+  };
+  const sep = getSeparators(locale);
+  let str = "",
+    decimals = -1;
+  for (let i = 0; i < valueString.length; i++) {
+    let c = valueString[i];
+    if (decimals >= 0 && /[0-9]/.test(c)) {
+      decimals++;
+      if (decimals > unit.magnitude) {
+        continue;
+      }
+    } else if (c === sep.decimal) {
+      decimals = 0;
+    }
+    str += c;
+  }
+  return str;
+};

--- a/packages/currencies/src/index.js
+++ b/packages/currencies/src/index.js
@@ -13,6 +13,8 @@ import {
 
 import { parseCurrencyUnit } from "./parseCurrencyUnit";
 
+import { chopCurrencyUnitDecimals } from "./chopCurrencyUnitDecimals";
+
 import {
   formatCurrencyUnit,
   formatCurrencyUnitFragment
@@ -27,6 +29,7 @@ export {
   getFiatUnit,
   hasFiatUnit,
   parseCurrencyUnit,
+  chopCurrencyUnitDecimals,
   formatCurrencyUnit,
   formatCurrencyUnitFragment,
   formatShort,

--- a/packages/currencies/src/parseCurrencyUnit.js
+++ b/packages/currencies/src/parseCurrencyUnit.js
@@ -7,7 +7,7 @@ const defaultFormatOptions = {
 };
 
 // returns decimal and thousands separator
-const getSeparators = memoize((locale: string): {
+export const getSeparators = memoize((locale: string): {
   decimal: ?string,
   thousands: ?string
 } => {

--- a/packages/currencies/tests/index.test.js
+++ b/packages/currencies/tests/index.test.js
@@ -10,6 +10,7 @@ import {
   countervalueForRate,
   formatCurrencyUnit,
   parseCurrencyUnit,
+  chopCurrencyUnitDecimals,
   formatShort,
   decodeURIScheme,
   encodeURIScheme
@@ -167,6 +168,20 @@ test("formatter can change locale", () => {
 test("formatShort", () => {
   expect(formatShort(getFiatUnit("EUR"), 123456789)).toBe("1.2m");
   expect(formatShort(getFiatUnit("EUR"), 123456)).toBe("1.2k");
+});
+
+test("chopCurrencyUnitDecimals", () => {
+  expect(chopCurrencyUnitDecimals(getFiatUnit("EUR"), "1")).toBe("1");
+  expect(chopCurrencyUnitDecimals(getFiatUnit("EUR"), "1,234")).toBe("1,234");
+  expect(chopCurrencyUnitDecimals(getFiatUnit("EUR"), "1,234.56")).toBe(
+    "1,234.56"
+  );
+  expect(chopCurrencyUnitDecimals(getFiatUnit("EUR"), "1,234.5678")).toBe(
+    "1,234.56"
+  );
+  expect(chopCurrencyUnitDecimals(getFiatUnit("EUR"), "1,234.5678 EUR")).toBe(
+    "1,234.56 EUR"
+  );
 });
 
 test("encodeURIScheme", () => {


### PR DESCRIPTION
typically will be used for the input text because we don't want to aggressively re-format it on key stroke