### PR TITLE
add subMagnitude option to formatCurrencyUnit

### DIFF
--- a/packages/currencies/src/formatCurrencyUnit.js
+++ b/packages/currencies/src/formatCurrencyUnit.js
@@ -5,12 +5,23 @@ import memoize from "lodash/memoize";
 const nonBreakableSpace = " ";
 const defaultFormatOptions = {
   locale: "en-EN",
+  // show the currency code
   showCode: false,
+  // always show the sign, even if it's a positive value
   alwaysShowSign: false,
   // override showAllDigits of the unit
   showAllDigits: false,
+  // disable the feature that only show significant digits
+  // and removes the negligible extra digits.
+  // (rounding is dynamically applied based on the value. higher value means more rounding)
   disableRounding: false,
-  useGrouping: true
+  // enable or not the thousands grouping (e.g; 1,234.00)
+  useGrouping: true,
+  // this allow to increase the number of digits displayed
+  // even if the currency don't allow more than this (sub-cent)
+  // a value of 1 can display USD 0.006 for instance. 2 can display USD 0.0065
+  // NB even if you set 3, USD 4.50 will be display as USD 4.50 , not 4.5000 (extra zeros are not displayed)
+  subMagnitude: 0
 };
 
 type FormatFragment =
@@ -59,7 +70,8 @@ export function formatCurrencyUnitFragment(
     showAllDigits,
     locale,
     disableRounding,
-    useGrouping
+    useGrouping,
+    subMagnitude
   } = {
     ...defaultFormatOptions,
     ...unit,
@@ -70,13 +82,16 @@ export function formatCurrencyUnitFragment(
   const floatValueAbs = Math.abs(floatValue);
   const minimumFractionDigits = showAllDigits ? magnitude : 0;
   const maximumFractionDigits = disableRounding
-    ? magnitude
+    ? magnitude + subMagnitude
     : Math.max(
         minimumFractionDigits,
         Math.max(
           0,
           // dynamic max number of digits based on the value itself. to only show significant part
-          Math.min(4 - Math.round(Math.log10(floatValueAbs)), magnitude)
+          Math.min(
+            4 - Math.round(Math.log10(floatValueAbs)),
+            magnitude + subMagnitude
+          )
         )
       );
 

--- a/packages/currencies/tests/index.test.js
+++ b/packages/currencies/tests/index.test.js
@@ -116,6 +116,61 @@ test("formatter rounding can be disabled", () => {
   ).toBe("9,999.99999999");
 });
 
+test("sub magnitude", () => {
+  expect(
+    formatCurrencyUnit(getFiatUnit("USD"), 0.04, {
+      subMagnitude: 2
+    })
+  ).toBe("0.0004");
+
+  // digits will be round after subMagnitude
+  expect(
+    formatCurrencyUnit(getFiatUnit("USD"), 0.03987654, {
+      subMagnitude: 2,
+      showCode: true
+    })
+  ).toBe("USD 0.0004");
+
+  expect(
+    formatCurrencyUnit(getFiatUnit("USD"), 0.03987654, {
+      subMagnitude: 2,
+      disableRounding: true
+    })
+  ).toBe("0.0004");
+
+  expect(
+    formatCurrencyUnit(getFiatUnit("USD"), 0.03987654, {
+      subMagnitude: 5,
+      disableRounding: true
+    })
+  ).toBe("0.0003988");
+
+  // even tho the USD unit showAllDigits, it does not force the sub magnitude digits to show
+  expect(
+    formatCurrencyUnit(getFiatUnit("USD"), 0.03, {
+      subMagnitude: 5,
+      disableRounding: true
+    })
+  ).toBe("0.0003");
+
+  expect(
+    formatCurrencyUnit(getCurrencyByCoinType(0).units[0], 9.123456, {
+      subMagnitude: 2
+    })
+  ).toBe("0.0000000912");
+  expect(
+    formatCurrencyUnit(getCurrencyByCoinType(0).units[0], 999999999999.123456, {
+      disableRounding: true,
+      subMagnitude: 2
+    })
+  ).toBe("9,999.9999999912");
+  expect(
+    formatCurrencyUnit(getCurrencyByCoinType(0).units[0], 999999999999.123456, {
+      subMagnitude: 2
+    })
+  ).toBe("10,000");
+});
+
 test("parseCurrencyUnit", () => {
   expect(
     parseCurrencyUnit(getCurrencyByCoinType(0).units[0], "9,999.99999999")


### PR DESCRIPTION
```js
// this allow to increase the number of digits displayed
// even if the currency don't allow more than this (sub-cent)
// a value of subMagnitude=1 can display USD 0.006 for instance. subMagnitude=2 can display USD 0.0065
// NB even if you set 3, USD 4.50 will be display as USD 4.50 , not 4.5000 (extra zeros are not displayed)

  expect(
    formatCurrencyUnit(getFiatUnit("USD"), 0.03987654, {
      subMagnitude: 2,
      showCode: true
    })
  ).toBe("USD 0.0004");
```

usecase is for displaying the rate. like doge coin is lower than a cent. `DOGE 1 = USD 0.002219` with a subMagnitude of 4 