### PR TITLE
currencies: changes in cryptocurrencies & fiat type

### DIFF
--- a/packages/currencies/src/countervalueForRate.js
+++ b/packages/currencies/src/countervalueForRate.js
@@ -4,6 +4,9 @@ import type { Rate, UnitValue } from "./types";
 
 // calculate the counter value at a specific rate
 export default (rate: Rate, value: number): UnitValue => {
+  console.log(
+    "DEPRECATED: countervalueForRate is deprecated. this logic needs to move out of currencies. for instance in wallet-common"
+  );
   const unit = getFiatUnit(rate.fiat);
   return {
     value: Math.round(rate.value * value),

--- a/packages/currencies/src/data/cryptocurrencies.js
+++ b/packages/currencies/src/data/cryptocurrencies.js
@@ -32,6 +32,7 @@ const cryptocurrenciesArray: Currency[] = [
   {
     coinType: 0,
     name: "Bitcoin",
+    ticker: "BTC",
     scheme: "bitcoin",
     apiName: "btc",
     color: "#ffae35",
@@ -54,6 +55,7 @@ const cryptocurrenciesArray: Currency[] = [
   {
     coinType: 1,
     name: "Bitcoin Testnet",
+    ticker: "BTC",
     scheme: "bitcoin",
     apiName: "btc_testnet",
     color: "#ffae35",
@@ -76,6 +78,7 @@ const cryptocurrenciesArray: Currency[] = [
   {
     coinType: 145,
     name: "Bitcoin Cash",
+    ticker: "BCH",
     scheme: "bitcoin",
     apiName: "abc",
     color: "#85bb65",
@@ -124,6 +127,7 @@ const cryptocurrenciesArray: Currency[] = [
   {
     coinType: 156,
     name: "Bitcoin Gold",
+    ticker: "BTG",
     scheme: "bitcoin",
     apiName: "btg",
     color: "#132c47",
@@ -172,6 +176,7 @@ const cryptocurrenciesArray: Currency[] = [
   {
     coinType: 2,
     name: "Litecoin",
+    ticker: "LTC",
     scheme: "litecoin",
     color: "#cccccc",
     units: [
@@ -186,6 +191,7 @@ const cryptocurrenciesArray: Currency[] = [
   {
     coinType: 3,
     name: "Dogecoin",
+    ticker: "DOGE",
     scheme: "dogecoin",
     color: "#65d196",
     units: [
@@ -200,6 +206,7 @@ const cryptocurrenciesArray: Currency[] = [
   {
     coinType: 5,
     name: "Dash",
+    ticker: "DASH",
     scheme: "dash",
     apiName: "dash",
     color: "#0e76aa",
@@ -228,6 +235,7 @@ const cryptocurrenciesArray: Currency[] = [
   {
     coinType: 6,
     name: "Peercoin",
+    ticker: "PPC",
     scheme: "peercoin",
     apiName: "ppc",
     color: "#3cb054",
@@ -256,6 +264,7 @@ const cryptocurrenciesArray: Currency[] = [
   {
     coinType: 105,
     name: "Stratis",
+    ticker: "STRAT",
     scheme: "stratis",
     apiName: "strat",
     color: "#1382c6",
@@ -284,6 +293,7 @@ const cryptocurrenciesArray: Currency[] = [
   {
     coinType: 133,
     name: "Zcash",
+    ticker: "ZEC",
     scheme: "zcash",
     apiName: "zec",
     color: "#3790ca",
@@ -312,6 +322,7 @@ const cryptocurrenciesArray: Currency[] = [
   {
     coinType: 141,
     name: "Komodo",
+    ticker: "KMD",
     scheme: "komodo",
     apiName: "kmd",
     color: "#326464",

--- a/packages/currencies/src/data/fiat.js
+++ b/packages/currencies/src/data/fiat.js
@@ -1,216 +1,69 @@
 //@flow
-import type { Unit } from "../types";
+import type { FiatUnit } from "../types";
 // inspired by https://github.com/smirzaei/currency-formatter/blob/master/currencies.json
-const units: { [key: string]: Unit } = {
-  AED: { name: "Emirati Dirham", code: "AED", symbol: "د.إ.", magnitude: 2 },
-  AFN: { name: "Afghan Afghani", code: "AFN", symbol: "؋", magnitude: 2 },
-  ALL: { name: "Albanian lek", code: "ALL", symbol: "Lek", magnitude: 2 },
-  AMD: { name: "Armenian dram", code: "AMD", symbol: "֏", magnitude: 2 },
-  ANG: { name: "Dutch Guilder", code: "ANG", symbol: "ƒ", magnitude: 2 },
-  AOA: { name: "Angolan Kwanza", code: "AOA", symbol: "Kz", magnitude: 2 },
-  ARS: { name: "Argentine peso", code: "ARS", symbol: "$", magnitude: 2 },
-  AUD: { name: "Australian Dollar", code: "AUD", symbol: "$", magnitude: 2 },
-  AWG: { name: "Arubin florin", code: "AWG", symbol: "ƒ", magnitude: 2 },
-  AZN: { name: "Azerbaijani manat", code: "AZN", symbol: "₼", magnitude: 2 },
-  BAM: {
-    name: "Bosnian Convertible Marka",
-    code: "BAM",
-    symbol: "КМ",
-    magnitude: 2
-  },
-  BBD: { name: "Barbadian dollar", code: "BBD", symbol: "$", magnitude: 2 },
-  BDT: { name: "Bangladeshi Taka", code: "BDT", symbol: "৳", magnitude: 0 },
-  BGN: { name: "Bulgarian lev", code: "BGN", symbol: "лв.", magnitude: 2 },
-  BHD: { name: "Bahraini Dinar", code: "BHD", symbol: "د.ب.", magnitude: 3 },
-  BIF: { name: "Burundian Franc", code: "BIF", symbol: "FBu", magnitude: 0 },
-  BMD: { name: "Bermudian dollar", code: "BMD", symbol: "$", magnitude: 2 },
-  BND: { name: "Bruneian Dollar", code: "BND", symbol: "$", magnitude: 0 },
-  BOB: { name: "Bolivian Boliviano", code: "BOB", symbol: "Bs", magnitude: 2 },
-  BRL: { name: "Brazilian real", code: "BRL", symbol: "R$", magnitude: 2 },
-  BSD: { name: "Bahamian dollar", code: "BSD", symbol: "$", magnitude: 2 },
-  BTN: { name: "Bhutanese Ngultrum", code: "BTN", symbol: "Nu.", magnitude: 1 },
-  BWP: { name: "Botswana Pula", code: "BWP", symbol: "P", magnitude: 2 },
-  BYR: { name: "Belarusian ruble", code: "BYR", symbol: "р.", magnitude: 2 },
-  BZD: { name: "Belize dollar", code: "BZD", symbol: "BZ$", magnitude: 2 },
-  CAD: { name: "Canadian Dollar", code: "CAD", symbol: "$", magnitude: 2 },
-  CDF: { name: "CDF", code: "CDF", symbol: "FC", magnitude: 2 },
-  CHF: { name: "Swiss Franc", code: "CHF", symbol: "CHF", magnitude: 2 },
-  CLP: { name: "Chilean Peso", code: "CLP", symbol: "$", magnitude: 2 },
-  CNY: {
-    name: "Yuan or chinese renminbi",
-    code: "CNY",
-    symbol: "¥",
-    magnitude: 2
-  },
-  COP: { name: "Colombian peso", code: "COP", symbol: "$", magnitude: 2 },
-  CRC: { name: "Costa Rican colón", code: "CRC", symbol: "₡", magnitude: 2 },
-  CUC: {
-    name: "Cuban convertible peso",
-    code: "CUC",
-    symbol: "CUC",
-    magnitude: 2
-  },
-  CUP: { name: "Cuban peso", code: "CUP", symbol: "$MN", magnitude: 2 },
-  CVE: { name: "Cape Verdean Escudo", code: "CVE", symbol: "$", magnitude: 2 },
-  CZK: { name: "Czech koruna", code: "CZK", symbol: "Kč", magnitude: 2 },
-  DJF: { name: "Djiboutian Franc", code: "DJF", symbol: "Fdj", magnitude: 0 },
-  DKK: { name: "Danish krone", code: "DKK", symbol: "kr.", magnitude: 2 },
-  DOP: { name: "Dominican peso", code: "DOP", symbol: "RD$", magnitude: 2 },
-  DZD: { name: "Algerian Dinar", code: "DZD", symbol: "د.ج.", magnitude: 2 },
-  EGP: { name: "Egyptian Pound", code: "EGP", symbol: "ج.م.", magnitude: 2 },
-  ERN: { name: "Eritrean nakfa", code: "ERN", symbol: "Nfk", magnitude: 2 },
-  ETB: { name: "Ethiopian Birr", code: "ETB", symbol: "ETB", magnitude: 2 },
-  EUR: { name: "Euro", code: "EUR", symbol: "€", magnitude: 2 },
-  FJD: { name: "Fijian dollar", code: "FJD", symbol: "$", magnitude: 2 },
-  FKP: {
-    name: "Falkland Island Pound",
-    code: "FKP",
-    symbol: "£",
-    magnitude: 2
-  },
-  GBP: { name: "British Pound", code: "GBP", symbol: "£", magnitude: 2 },
-  GEL: { name: "Georgian lari", code: "GEL", symbol: "Lari", magnitude: 2 },
-  GHS: { name: "Ghanaian Cedi", code: "GHS", symbol: "₵", magnitude: 2 },
-  GIP: { name: "Gibraltar pound", code: "GIP", symbol: "£", magnitude: 2 },
-  GMD: { name: "Gambian dalasi", code: "GMD", symbol: "D", magnitude: 2 },
-  GNF: { name: "Guinean Franc", code: "GNF", symbol: "FG", magnitude: 0 },
-  GTQ: { name: "Guatemalan Quetzal", code: "GTQ", symbol: "Q", magnitude: 2 },
-  GYD: { name: "Guyanese dollar", code: "GYD", symbol: "$", magnitude: 2 },
-  HKD: { name: "Hong Kong dollar", code: "HKD", symbol: "HK$", magnitude: 2 },
-  HNL: { name: "Honduran lempira", code: "HNL", symbol: "L.", magnitude: 2 },
-  HRK: { name: "Croatian kuna", code: "HRK", symbol: "kn", magnitude: 2 },
-  HTG: { name: "Haitian gourde", code: "HTG", symbol: "G", magnitude: 2 },
-  HUF: { name: "Hungarian forint", code: "HUF", symbol: "Ft", magnitude: 2 },
-  IDR: { name: "Indonesian Rupiah", code: "IDR", symbol: "Rp", magnitude: 0 },
-  ILS: { name: "Israeli Shekel", code: "ILS", symbol: "₪", magnitude: 2 },
-  INR: { name: "Indian Rupee", code: "INR", symbol: "₹", magnitude: 2 },
-  IQD: { name: "Iraqi Dinar", code: "IQD", symbol: "د.ع.", magnitude: 2 },
-  IRR: { name: "Iranian Rial", code: "IRR", symbol: "﷼", magnitude: 2 },
-  ISK: { name: "Icelandic Krona", code: "ISK", symbol: "kr.", magnitude: 0 },
-  JMD: { name: "Jamaican dollar", code: "JMD", symbol: "J$", magnitude: 2 },
-  JOD: { name: "Jordanian Dinar", code: "JOD", symbol: "د.ا.", magnitude: 3 },
-  JPY: { name: "Japanese yen", code: "JPY", symbol: "¥", magnitude: 0 },
-  KES: { name: "Kenyan Shilling", code: "KES", symbol: "S", magnitude: 2 },
-  KGS: { name: "Kyrgyzstani som", code: "KGS", symbol: "сом", magnitude: 2 },
-  KHR: { name: "Cambodian Riel", code: "KHR", symbol: "៛", magnitude: 0 },
-  KMF: { name: "Comoran Franc", code: "KMF", symbol: "CF", magnitude: 2 },
-  KPW: { name: "North Korean won", code: "KPW", symbol: "₩", magnitude: 0 },
-  KRW: { name: "South Korean won", code: "KRW", symbol: "₩", magnitude: 0 },
-  KWD: { name: "Kuwaiti Dinar", code: "KWD", symbol: "د.ك.", magnitude: 3 },
-  KYD: { name: "Caymanian Dollar", code: "KYD", symbol: "$", magnitude: 2 },
-  KZT: { name: "Kazakhstani tenge", code: "KZT", symbol: "₸", magnitude: 2 },
-  LAK: { name: "Lao or Laotian Kip", code: "LAK", symbol: "₭", magnitude: 0 },
-  LBP: { name: "Lebanese Pound", code: "LBP", symbol: "ل.ل.", magnitude: 2 },
-  LKR: { name: "Sri Lankan Rupee", code: "LKR", symbol: "₨", magnitude: 0 },
-  LRD: { name: "Liberian Dollar", code: "LRD", symbol: "$", magnitude: 2 },
-  LSL: { name: "Lesotho loti", code: "LSL", symbol: "M", magnitude: 2 },
-  LYD: { name: "Libyan Dinar", code: "LYD", symbol: "د.ل.", magnitude: 3 },
-  MAD: { name: "Moroccan Dirham", code: "MAD", symbol: "د.م.", magnitude: 2 },
-  MDL: { name: "Moldovan Leu", code: "MDL", symbol: "lei", magnitude: 2 },
-  MGA: { name: "Malagasy Ariary", code: "MGA", symbol: "Ar", magnitude: 0 },
-  MKD: { name: "Macedonian Denar", code: "MKD", symbol: "ден.", magnitude: 2 },
-  MMK: { name: "Burmese Kyat", code: "MMK", symbol: "K", magnitude: 2 },
-  MNT: { name: "Mongolian Tughrik", code: "MNT", symbol: "₮", magnitude: 2 },
-  MOP: { name: "Macau Pataca", code: "MOP", symbol: "MOP$", magnitude: 2 },
-  MRO: { name: "Mauritanian Ouguiya", code: "MRO", symbol: "UM", magnitude: 2 },
-  MTL: { name: "MTL", code: "MTL", symbol: "₤", magnitude: 2 },
-  MUR: { name: "Mauritian rupee", code: "MUR", symbol: "₨", magnitude: 2 },
-  MVR: { name: "Maldivian Rufiyaa", code: "MVR", symbol: "MVR", magnitude: 1 },
-  MWK: { name: "Malawian Kwacha", code: "MWK", symbol: "MK", magnitude: 2 },
-  MXN: { name: "Mexico Peso", code: "MXN", symbol: "$", magnitude: 2 },
-  MYR: { name: "Malaysian Ringgit", code: "MYR", symbol: "RM", magnitude: 2 },
-  MZN: { name: "Mozambican Metical", code: "MZN", symbol: "MT", magnitude: 0 },
-  NAD: { name: "Namibian Dollar", code: "NAD", symbol: "$", magnitude: 2 },
-  NGN: { name: "Nigerian Naira", code: "NGN", symbol: "₦", magnitude: 2 },
-  NIO: { name: "Nicaraguan córdoba", code: "NIO", symbol: "C$", magnitude: 2 },
-  NOK: { name: "Norwegian krone", code: "NOK", symbol: "kr", magnitude: 2 },
-  NPR: { name: "Nepalese Rupee", code: "NPR", symbol: "₨", magnitude: 2 },
-  NZD: { name: "New Zealand Dollar", code: "NZD", symbol: "$", magnitude: 2 },
-  OMR: { name: "Omani Rial", code: "OMR", symbol: "﷼", magnitude: 3 },
-  PAB: { name: "Balboa panamérn", code: "PAB", symbol: "B/.", magnitude: 2 },
-  PEN: { name: "Peruvian nuevo sol", code: "PEN", symbol: "S/.", magnitude: 2 },
-  PGK: {
-    name: "Papua New Guinean Kina",
-    code: "PGK",
-    symbol: "K",
-    magnitude: 2
-  },
-  PHP: { name: "Philippine Peso", code: "PHP", symbol: "₱", magnitude: 2 },
-  PKR: { name: "Pakistani Rupee", code: "PKR", symbol: "₨", magnitude: 2 },
-  PLN: { name: "Polish złoty", code: "PLN", symbol: "zł", magnitude: 2 },
-  PYG: { name: "Paraguayan guarani", code: "PYG", symbol: "₲", magnitude: 2 },
-  QAR: { name: "Qatari Riyal", code: "QAR", symbol: "﷼", magnitude: 2 },
-  RON: { name: "Romanian leu", code: "RON", symbol: "lei", magnitude: 2 },
-  RSD: { name: "Serbian Dinar", code: "RSD", symbol: "Дин.", magnitude: 2 },
-  RUB: { name: "Russian Rouble", code: "RUB", symbol: "₽", magnitude: 2 },
-  RWF: { name: "Rwandan franc", code: "RWF", symbol: "RWF", magnitude: 2 },
-  SAR: { name: "Saudi Arabian Riyal", code: "SAR", symbol: "﷼", magnitude: 2 },
-  SBD: {
-    name: "Solomon Islander Dollar",
-    code: "SBD",
-    symbol: "$",
-    magnitude: 2
-  },
-  SCR: { name: "Seychellois Rupee", code: "SCR", symbol: "₨", magnitude: 2 },
-  SDD: { name: "SDD", code: "SDD", symbol: "LSd", magnitude: 2 },
-  SDG: { name: "Sudanese Pound", code: "SDG", symbol: "£", magnitude: 2 },
-  SEK: { name: "Swedish krona", code: "SEK", symbol: "kr", magnitude: 2 },
-  SGD: { name: "Singapore Dollar", code: "SGD", symbol: "$", magnitude: 2 },
-  SHP: { name: "SHP", code: "SHP", symbol: "£", magnitude: 2 },
-  SLL: {
-    name: "Sierra Leonean Leone",
-    code: "SLL",
-    symbol: "Le",
-    magnitude: 2
-  },
-  SOS: { name: "Somali Shilling", code: "SOS", symbol: "S", magnitude: 2 },
-  SRD: { name: "Surinamese dollar", code: "SRD", symbol: "$", magnitude: 2 },
-  STD: { name: "STD", code: "STD", symbol: "Db", magnitude: 2 },
-  SVC: { name: "SVC", code: "SVC", symbol: "₡", magnitude: 2 },
-  SYP: { name: "Syrian Pound", code: "SYP", symbol: "£", magnitude: 2 },
-  SZL: { name: "Swazi Lilangeni", code: "SZL", symbol: "E", magnitude: 2 },
-  THB: { name: "Thai Baht", code: "THB", symbol: "฿", magnitude: 2 },
-  TJS: { name: "Tajikistani somoni", code: "TJS", symbol: "TJS", magnitude: 2 },
-  TMT: { name: "Turkmenistan manat", code: "TMT", symbol: "m", magnitude: 0 },
-  TND: { name: "Tunisian Dinar", code: "TND", symbol: "د.ت.", magnitude: 3 },
-  TOP: { name: "Tongan Pa'anga", code: "TOP", symbol: "T$", magnitude: 2 },
-  TRY: { name: "Turkish Lira", code: "TRY", symbol: "TL", magnitude: 2 },
-  TTD: { name: "Trinidadian dollar", code: "TTD", symbol: "TT$", magnitude: 2 },
-  TVD: { name: "TVD", code: "TVD", symbol: "$", magnitude: 2 },
-  TWD: { name: "Taiwan New Dollar", code: "TWD", symbol: "NT$", magnitude: 2 },
-  TZS: { name: "Tanzanian Shilling", code: "TZS", symbol: "TSh", magnitude: 2 },
-  UAH: { name: "Ukrainian Hryvnia", code: "UAH", symbol: "₴", magnitude: 2 },
-  UGX: { name: "Ugandan Shilling", code: "UGX", symbol: "USh", magnitude: 2 },
-  USD: { name: "US Dollar", code: "USD", symbol: "$", magnitude: 2 },
-  UYU: { name: "Uruguayan peso", code: "UYU", symbol: "$U", magnitude: 2 },
-  UZS: { name: "Uzbekistani som", code: "UZS", symbol: "сўм", magnitude: 2 },
-  VEB: { name: "VEB", code: "VEB", symbol: "Bs.", magnitude: 2 },
-  VEF: {
-    name: "Venezuelan bolivar",
-    code: "VEF",
-    symbol: "Bs. F.",
-    magnitude: 2
-  },
-  VND: { name: "Vietnamese Dong", code: "VND", symbol: "₫", magnitude: 1 },
-  VUV: { name: "Ni-Vanuatu Vatu", code: "VUV", symbol: "VT", magnitude: 0 },
-  WST: { name: "Samoan Tālā", code: "WST", symbol: "WS$", magnitude: 2 },
-  XAF: { name: "XAF", code: "XAF", symbol: "F", magnitude: 2 },
-  XCD: {
-    name: "East Caribbean dollar",
-    code: "XCD",
-    symbol: "$",
-    magnitude: 2
-  },
-  XOF: { name: "CFA Franc", code: "XOF", symbol: "F", magnitude: 2 },
-  XPF: { name: "CFP Franc", code: "XPF", symbol: "F", magnitude: 2 },
-  YER: { name: "Yemeni Rial", code: "YER", symbol: "﷼", magnitude: 2 },
-  ZAR: { name: "South African Rand", code: "ZAR", symbol: "R", magnitude: 2 },
-  ZMW: { name: "Zambian Kwacha", code: "ZMW", symbol: "ZK", magnitude: 2 },
-  WON: { name: "WON", code: "WON", symbol: "₩", magnitude: 2 }
-};
-for (let u in units) {
-  units[u].showAllDigits = true;
+
+function fiat(name, ticker, symbol, magnitude): FiatUnit {
+  return {
+    ticker,
+    code: ticker, // code is always the ticker (when formatting currencies)
+    name,
+    symbol,
+    magnitude,
+    showAllDigits: true
+  };
 }
+
+const units: { [key: string]: FiatUnit } = {
+  AED: fiat("Emirati Dirham", "AED", "د.إ.", 2),
+  AUD: fiat("Australian Dollar", "AUD", "$", 2),
+  BGN: fiat("Bulgarian lev", "BGN", "лв.", 2),
+  BHD: fiat("Bahraini Dinar", "BHD", "د.ب.", 3),
+  BRL: fiat("Brazilian real", "BRL", "R$", 2),
+  CAD: fiat("Canadian Dollar", "CAD", "$", 2),
+  CHF: fiat("Swiss Franc", "CHF", "CHF", 2),
+  CLP: fiat("Chilean Peso", "CLP", "$", 2),
+  CNY: fiat("Yuan or chinese renminbi", "CNY", "¥", 2),
+  CRC: fiat("Costa Rican colón", "CRC", "₡", 2),
+  CZK: fiat("Czech koruna", "CZK", "Kč", 2),
+  DKK: fiat("Danish krone", "DKK", "kr.", 2),
+  EUR: fiat("Euro", "EUR", "€", 2),
+  GBP: fiat("British Pound", "GBP", "£", 2),
+  GHS: fiat("Ghanaian Cedi", "GHS", "₵", 2),
+  HKD: fiat("Hong Kong dollar", "HKD", "HK$", 2),
+  HRK: fiat("Croatian kuna", "HRK", "kn", 2),
+  HUF: fiat("Hungarian forint", "HUF", "Ft", 2),
+  IDR: fiat("Indonesian Rupiah", "IDR", "Rp", 0),
+  ILS: fiat("Israeli Shekel", "ILS", "₪", 2),
+  INR: fiat("Indian Rupee", "INR", "₹", 2),
+  IRR: fiat("Iranian Rial", "IRR", "﷼", 2),
+  JPY: fiat("Japanese yen", "JPY", "¥", 0),
+  KES: fiat("Kenyan Shilling", "KES", "S", 2),
+  KHR: fiat("Cambodian Riel", "KHR", "៛", 0),
+  KRW: fiat("South Korean won", "KRW", "₩", 0),
+  MUR: fiat("Mauritian rupee", "MUR", "₨", 2),
+  MXN: fiat("Mexico Peso", "MXN", "$", 2),
+  MYR: fiat("Malaysian Ringgit", "MYR", "RM", 2),
+  NGN: fiat("Nigerian Naira", "NGN", "₦", 2),
+  NOK: fiat("Norwegian krone", "NOK", "kr", 2),
+  NZD: fiat("New Zealand Dollar", "NZD", "$", 2),
+  PHP: fiat("Philippine Peso", "PHP", "₱", 2),
+  PKR: fiat("Pakistani Rupee", "PKR", "₨", 2),
+  PLN: fiat("Polish złoty", "PLN", "zł", 2),
+  RON: fiat("Romanian leu", "RON", "lei", 2),
+  RUB: fiat("Russian Rouble", "RUB", "₽", 2),
+  SEK: fiat("Swedish krona", "SEK", "kr", 2),
+  SGD: fiat("Singapore Dollar", "SGD", "$", 2),
+  THB: fiat("Thai Baht", "THB", "฿", 2),
+  TRY: fiat("Turkish Lira", "TRY", "TL", 2),
+  TZS: fiat("Tanzanian Shilling", "TZS", "TSh", 2),
+  UAH: fiat("Ukrainian Hryvnia", "UAH", "₴", 2),
+  UGX: fiat("Ugandan Shilling", "UGX", "USh", 2),
+  USD: fiat("US Dollar", "USD", "$", 2),
+  VEF: fiat("Venezuelan bolivar", "VEF", "Bs. F.", 2),
+  VND: fiat("Vietnamese Dong", "VND", "₫", 1),
+  VUV: fiat("Ni-Vanuatu Vatu", "VUV", "VT", 0),
+  ZAR: fiat("South African Rand", "ZAR", "R", 2)
+};
 
 export type Fiat = $Keys<typeof units>;
 
@@ -218,10 +71,16 @@ export function hasFiatUnit(fiat: string): boolean {
   return fiat in units;
 }
 
-export function getFiatUnit(fiat: string): Unit {
-  const unit = units[fiat];
+export function getFiatUnit(fiat: string): FiatUnit {
+  const unit: FiatUnit = units[fiat];
   if (!unit) {
     throw new Error(`unit "${fiat}" not found`);
   }
   return unit;
+}
+
+const list = Object.keys(units).map(k => units[k]);
+
+export function listFiats(): FiatUnit[] {
+  return list;
 }

--- a/packages/currencies/src/index.js
+++ b/packages/currencies/src/index.js
@@ -2,7 +2,7 @@
 
 import { encodeURIScheme, decodeURIScheme } from "./CurrencyURIScheme";
 
-import { getFiatUnit, hasFiatUnit } from "./data/fiat";
+import { listFiats, getFiatUnit, hasFiatUnit } from "./data/fiat";
 
 import {
   listCurrencies,
@@ -25,6 +25,7 @@ import { formatShort } from "./formatShort";
 import countervalueForRate from "./countervalueForRate";
 
 export {
+  listFiats,
   listCurrencies,
   getFiatUnit,
   hasFiatUnit,

--- a/packages/currencies/src/types.js
+++ b/packages/currencies/src/types.js
@@ -6,7 +6,7 @@ export type Rate = {
   fiat: Fiat
 };
 
-export type Unit = {|
+export type Unit = {
   // display name of a given unit (exemple: satoshi)
   name: string,
   // string to use when formatting the unit. like 'BTC' or 'USD'
@@ -17,7 +17,11 @@ export type Unit = {|
   symbol?: string,
   // should it always print all digits even if they are 0 (usually: true for fiats, false for cryptos)
   showAllDigits?: boolean
-|};
+};
+
+export type FiatUnit = Unit & {
+  ticker: string
+};
 
 export type UnitValue = {| value: number, unit: Unit |};
 
@@ -38,6 +42,8 @@ export type Currency = {|
   coinType: number,
   // display name of a currency
   name: string,
+  // the ticker name in exchanges / countervalue apis (e.g. BTC)
+  ticker: string,
   // the scheme name to use when formatting an URI (without the ':')
   scheme: string,
   // used for UI

--- a/packages/currencies/tests/index.test.js
+++ b/packages/currencies/tests/index.test.js
@@ -1,6 +1,7 @@
 //@flow
 
 import {
+  listFiats,
   listCurrencies,
   hasCurrencyByCoinType,
   getCurrencyByCoinType,
@@ -34,6 +35,41 @@ test("all cryptocurrencies have at least one unit", () => {
   for (let c of listCurrencies()) {
     expect(c.units.length).toBeGreaterThan(0);
   }
+});
+
+test("fiats list is always the same", () => {
+  expect(listFiats()).toEqual(listFiats());
+});
+
+test("fiats list elements are correct", () => {
+  const tickers = {};
+  for (const fiat of listFiats()) {
+    expect(tickers[fiat.ticker]).toBeFalsy();
+    expect(fiat.code).toBeTruthy();
+    expect(typeof fiat.code).toBe("string");
+    expect(fiat.ticker).toBeTruthy();
+    expect(typeof fiat.ticker).toBe("string");
+    expect(fiat.name).toBeTruthy();
+    expect(typeof fiat.name).toBe("string");
+    expect(fiat.symbol).toBeTruthy();
+    expect(typeof fiat.symbol).toBe("string");
+    expect(fiat.magnitude).toBeGreaterThan(-1);
+    expect(typeof fiat.magnitude).toBe("number");
+    tickers[fiat.ticker] = fiat;
+  }
+});
+
+test("fiats list is sorted by ticker", () => {
+  expect(
+    listFiats()
+      .map(fiat => fiat.ticker)
+      .join(",")
+  ).toEqual(
+    listFiats()
+      .map(fiat => fiat.ticker)
+      .sort((a, b) => (a > b ? 1 : -1))
+      .join(",")
+  );
 });
 
 test("can get fiat by coin type", () => {


### PR DESCRIPTION
- fiat has been a bit reduced to only contain the fiat that have pairs in crypto world ( according to https://min-api.cryptocompare.com/data/all/exchanges )
- fiat now also include a "ticker" field. which is the same as "code" at the moment. but that we should use to refer a fiat in API / exchanges etc
- currency also have a "ticker" field for the same usecase. it was a hack to use currency.units[0].code and we'll migrate these
- fiat unit have its own type