### PR TITLE
parseCurrencyUnit & chopCurrencyUnitDecimals to be locale independant

### DIFF
--- a/packages/currencies/src/chopCurrencyUnitDecimals.js
+++ b/packages/currencies/src/chopCurrencyUnitDecimals.js
@@ -1,24 +1,16 @@
 //@flow
 import type { Unit } from "./types";
-import { getSeparators } from "./parseCurrencyUnit";
-
-const defaultFormatOptions = {
-  locale: "en-EN"
-};
 
 // remove the extra decimals that can't be represented in unit
 // this function will preserve the string characters
-// for instance EUR 1,230.00234 will be transformed to EUR 1,230.00
+// for instance EUR 1230.00234 will be transformed to EUR 1230.00
+// NB this function parse a subset of formats because it it locale independant.
+// make sure you have at least following options set on the formatter:
+// - useGrouping: true
 export const chopCurrencyUnitDecimals = (
   unit: Unit,
-  valueString: string,
-  options?: $Shape<typeof defaultFormatOptions>
+  valueString: string
 ): string => {
-  const { locale } = {
-    ...defaultFormatOptions,
-    ...options
-  };
-  const sep = getSeparators(locale);
   let str = "",
     decimals = -1;
   for (let i = 0; i < valueString.length; i++) {
@@ -28,7 +20,7 @@ export const chopCurrencyUnitDecimals = (
       if (decimals > unit.magnitude) {
         continue;
       }
-    } else if (c === sep.decimal) {
+    } else if (c === "," || c === ".") {
       decimals = 0;
     }
     str += c;

--- a/packages/currencies/src/formatCurrencyUnit.js
+++ b/packages/currencies/src/formatCurrencyUnit.js
@@ -1,6 +1,6 @@
 //@flow
 import type { Unit } from "./types";
-import memoize from "lodash/memoize";
+import { getFragPositions } from "./localeUtility";
 
 const nonBreakableSpace = " ";
 const defaultFormatOptions = {
@@ -29,35 +29,6 @@ type FormatFragment =
   | { kind: "sign", value: string }
   | { kind: "code", value: string }
   | { kind: "separator", value: string };
-
-const getFragPositions = memoize((locale: string): Array<*> => {
-  const res = (-1).toLocaleString(locale, {
-    currency: "USD",
-    style: "currency"
-  });
-  const frags = [];
-  let mandatoryFrags = 0;
-  for (let i = 0; i < res.length; i++) {
-    const c = res[i];
-    if (c === "$") {
-      // force code to be surround by separators. we'll dedup later
-      frags.push("separator");
-      frags.push("code");
-      frags.push("separator");
-      mandatoryFrags++;
-    } else if (c === "-") {
-      frags.push("sign");
-      mandatoryFrags++;
-    } else if (c === "1") {
-      frags.push("value");
-      mandatoryFrags++;
-    } else if (/\s/.test(c)) {
-      frags.push("separator");
-    }
-    if (mandatoryFrags === 3) return frags;
-  }
-  return frags;
-});
 
 export function formatCurrencyUnitFragment(
   unit: Unit,

--- a/packages/currencies/src/localeUtility.js
+++ b/packages/currencies/src/localeUtility.js
@@ -1,0 +1,51 @@
+//@flow
+
+import memoize from "lodash/memoize";
+
+export const getFragPositions = memoize((locale: string): Array<*> => {
+  const res = (-1).toLocaleString(locale, {
+    currency: "USD",
+    style: "currency"
+  });
+  const frags = [];
+  let mandatoryFrags = 0;
+  for (let i = 0; i < res.length; i++) {
+    const c = res[i];
+    if (c === "$") {
+      // force code to be surround by separators. we'll dedup later
+      frags.push("separator");
+      frags.push("code");
+      frags.push("separator");
+      mandatoryFrags++;
+    } else if (c === "-") {
+      frags.push("sign");
+      mandatoryFrags++;
+    } else if (c === "1") {
+      frags.push("value");
+      mandatoryFrags++;
+    } else if (/\s/.test(c)) {
+      frags.push("separator");
+    }
+    if (mandatoryFrags === 3) return frags;
+  }
+  return frags;
+});
+
+// returns decimal and thousands separator
+export const getSeparators = memoize((locale: string): {
+  decimal: ?string,
+  thousands: ?string
+} => {
+  const res = (10000.2).toLocaleString(locale);
+  let decimal, thousands;
+  for (let i = 0; i < res.length; i++) {
+    const c = res[i];
+    if (/[0-9]/.test(c)) continue;
+    if (!thousands) {
+      thousands = c;
+    } else {
+      decimal = c;
+    }
+  }
+  return { decimal, thousands };
+});

--- a/packages/currencies/src/parseCurrencyUnit.js
+++ b/packages/currencies/src/parseCurrencyUnit.js
@@ -1,47 +1,13 @@
 //@flow
 import type { Unit } from "./types";
-import memoize from "lodash/memoize";
 
-const defaultFormatOptions = {
-  locale: "en-EN"
-};
-
-// returns decimal and thousands separator
-export const getSeparators = memoize((locale: string): {
-  decimal: ?string,
-  thousands: ?string
-} => {
-  const res = (10000.2).toLocaleString(locale);
-  let decimal, thousands;
-  for (let i = 0; i < res.length; i++) {
-    const c = res[i];
-    if (/[0-9]/.test(c)) continue;
-    if (!thousands) {
-      thousands = c;
-    } else {
-      decimal = c;
-    }
-  }
-  return { decimal, thousands };
-});
-
-export const parseCurrencyUnit = (
-  unit: Unit,
-  valueString: string,
-  options?: $Shape<typeof defaultFormatOptions>
-): number => {
-  const { locale } = {
-    ...defaultFormatOptions,
-    ...options
-  };
-  const sep = getSeparators(locale);
-  let str = "";
-  for (let i = 0; i < valueString.length; i++) {
-    let c = valueString[i];
-    if (c !== sep.thousands) {
-      str += c === sep.decimal ? "." : c;
-    }
-  }
+// parse a value that was formatted with formatCurrencyUnit
+// NB this function parse a subset of formats because it it locale independant.
+// make sure you have at least following options set on the formatter:
+// - useGrouping: true
+// - showCode: false
+export const parseCurrencyUnit = (unit: Unit, valueString: string): number => {
+  const str = valueString.replace(/,/g, ".");
   const value = parseFloat(str);
   if (isNaN(value)) return 0;
   return Math.round(value * 10 ** unit.magnitude);

--- a/packages/currencies/tests/index.test.js
+++ b/packages/currencies/tests/index.test.js
@@ -173,12 +173,12 @@ test("sub magnitude", () => {
 
 test("parseCurrencyUnit", () => {
   expect(
-    parseCurrencyUnit(getCurrencyByCoinType(0).units[0], "9,999.99999999")
+    parseCurrencyUnit(getCurrencyByCoinType(0).units[0], "9999.99999999")
   ).toBe(999999999999);
   expect(parseCurrencyUnit(getCurrencyByCoinType(0).units[0], ".987654")).toBe(
     98765400
   );
-  expect(parseCurrencyUnit(getCurrencyByCoinType(0).units[0], "9,999")).toBe(
+  expect(parseCurrencyUnit(getCurrencyByCoinType(0).units[0], "9999")).toBe(
     999900000000
   );
   expect(parseCurrencyUnit(getCurrencyByCoinType(0).units[0], "1")).toBe(
@@ -227,15 +227,15 @@ test("formatShort", () => {
 
 test("chopCurrencyUnitDecimals", () => {
   expect(chopCurrencyUnitDecimals(getFiatUnit("EUR"), "1")).toBe("1");
-  expect(chopCurrencyUnitDecimals(getFiatUnit("EUR"), "1,234")).toBe("1,234");
-  expect(chopCurrencyUnitDecimals(getFiatUnit("EUR"), "1,234.56")).toBe(
-    "1,234.56"
+  expect(chopCurrencyUnitDecimals(getFiatUnit("EUR"), "1234")).toBe("1234");
+  expect(chopCurrencyUnitDecimals(getFiatUnit("EUR"), "1234.56")).toBe(
+    "1234.56"
   );
-  expect(chopCurrencyUnitDecimals(getFiatUnit("EUR"), "1,234.5678")).toBe(
-    "1,234.56"
+  expect(chopCurrencyUnitDecimals(getFiatUnit("EUR"), "1234.5678")).toBe(
+    "1234.56"
   );
-  expect(chopCurrencyUnitDecimals(getFiatUnit("EUR"), "1,234.5678 EUR")).toBe(
-    "1,234.56 EUR"
+  expect(chopCurrencyUnitDecimals(getFiatUnit("EUR"), "1234.5678 EUR")).toBe(
+    "1234.56 EUR"
   );
 });
 


### PR DESCRIPTION
- the problem is: we can't control if user input '.' or ',', we should accept both, and treat them both as a decimal separation
- that means we can't support anymore the thousands separator (aka grouping)