### PR TITLE
Update to import es5 version of hooked-wallet

### DIFF
--- a/packages/web3-subprovider/package.json
+++ b/packages/web3-subprovider/package.json
@@ -33,7 +33,7 @@
     "@ledgerhq/hw-transport-u2f": "^4.7.3",
     "ethereumjs-tx": "^1.3.3",
     "strip-hex-prefix": "^1.0.0",
-    "web3-provider-engine": "^13.6.6"
+    "web3-provider-engine": "^14.0.2"
   },
   "devDependencies": {
     "flow-bin": "^0.68.0",

--- a/packages/web3-subprovider/src/index.js
+++ b/packages/web3-subprovider/src/index.js
@@ -1,7 +1,7 @@
 //@flow
 import AppEth from "@ledgerhq/hw-app-eth";
 import type Transport from "@ledgerhq/hw-transport";
-import HookedWalletSubprovider from "web3-provider-engine/subproviders/hooked-wallet";
+import HookedWalletSubprovider from "web3-provider-engine/dist/es5/subproviders/hooked-wallet";
 import stripHexPrefix from "strip-hex-prefix";
 import EthereumTx from "ethereumjs-tx";
 


### PR DESCRIPTION
- Updated web3-provider-engine to 14.0.2
- Change HookedWalletSubprovider import to `web3-provider-engine/dist/es5/subproviders/hooked-wallet`