### PR TITLE
feat(hw-app-str): generalize for more networks

### DIFF
--- a/packages/hw-app-str/src/utils.js
+++ b/packages/hw-app-str/src/utils.js
@@ -104,7 +104,6 @@ export function hash(data: Buffer) {
 }
 
 export function checkStellarBip32Path(path: string): void {
-
   path.split("/").forEach(function(element) {
     if (!element.toString().endsWith("'")) {
       throw new Error(

--- a/packages/hw-app-str/src/utils.js
+++ b/packages/hw-app-str/src/utils.js
@@ -103,13 +103,20 @@ export function hash(data: Buffer) {
   return hasher.digest();
 }
 
+const knownStellarTechBIPs = [
+  "148", // stellar.org
+  "5248" // ficnetwork.com
+];
+
 export function checkStellarBip32Path(path: string): void {
-  if (!path.startsWith("44'/148'")) {
+  if (!knownStellarTechBIPs.some(bip => path.startsWith("44'/" + bip + "'"))) {
     throw new Error(
-      "Not a Stellar BIP32 path. Path: " +
+      "Not a BIP32 path of known networks using Stellar technology. Path: " +
         path +
         "." +
-        " The Stellar app is authorized only for paths starting with 44'/148'." +
+        " The Stellar app is authorized only for paths starting with " +
+        knownStellarTechBIPs.map(bip => "44'/" + bip + "'").join(", ") +
+        "." +
         " Example: 44'/148'/0'"
     );
   }

--- a/packages/hw-app-str/src/utils.js
+++ b/packages/hw-app-str/src/utils.js
@@ -103,23 +103,8 @@ export function hash(data: Buffer) {
   return hasher.digest();
 }
 
-const knownStellarTechBIPs = [
-  "148", // stellar.org
-  "5248" // ficnetwork.com
-];
-
 export function checkStellarBip32Path(path: string): void {
-  if (!knownStellarTechBIPs.some(bip => path.startsWith("44'/" + bip + "'"))) {
-    throw new Error(
-      "Not a BIP32 path of known networks using Stellar technology. Path: " +
-        path +
-        "." +
-        " The Stellar app is authorized only for paths starting with " +
-        knownStellarTechBIPs.map(bip => "44'/" + bip + "'").join(", ") +
-        "." +
-        " Example: 44'/148'/0'"
-    );
-  }
+
   path.split("/").forEach(function(element) {
     if (!element.toString().endsWith("'")) {
       throw new Error(


### PR DESCRIPTION
At [ledger-app-stellar #11](https://github.com/lenondupe/ledger-app-stellar/issues/11) it was clear that each Stellar technology based network will have to make it's own app. Nevertheless, I see that with this change it's easy to use the same companion Javascript library for all of them.

Tested and works for me with [FIC Network](https://github.com/ficnetwork/ledger-app-fic).

Is this the right way to move forward?