### PR TITLE
Make transport hid actually logging the APDU instead of read/write

### DIFF
--- a/packages/hw-transport-node-hid/src/TransportNodeHid.js
+++ b/packages/hw-transport-node-hid/src/TransportNodeHid.js
@@ -229,7 +229,15 @@ export default class TransportNodeHid extends Transport<string> {
       return response;
     }
 
+    const { debug } = this;
     const deferred = defer();
+    if (debug) {
+      debug("=>" + apdu.toString("hex"));
+      deferred.promise.then(result => {
+        debug("<= " + result.toString("hex"));
+      });
+    }
+
     let exchangeTimeout;
     let transport;
     if (!this.ledgerTransport) {
@@ -254,10 +262,6 @@ export default class TransportNodeHid extends Transport<string> {
         const deferred = this.exchangeStack[0];
 
         const send = content => {
-          const { debug } = this;
-          if (debug) {
-            debug("=>" + content.toString("hex"));
-          }
           const data = [0x00];
           for (let i = 0; i < content.length; i++) {
             data.push(content[i]);
@@ -272,10 +276,6 @@ export default class TransportNodeHid extends Transport<string> {
               if (err || !res) reject(err);
               else {
                 const buffer = Buffer.from(res);
-                const { debug } = this;
-                if (debug) {
-                  debug("<=" + buffer.toString("hex"));
-                }
                 resolve(buffer);
               }
             })

--- a/packages/hw-transport/package.json
+++ b/packages/hw-transport/package.json
@@ -23,7 +23,7 @@
   "main": "lib/Transport.js",
   "license": "Apache-2.0",
   "dependencies": {
-    "events": "^2.0.0"
+    "events": "^3.0.0"
   },
   "devDependencies": {
     "flow-bin": "^0.68.0",

--- a/packages/hw-transport/src/Transport.js
+++ b/packages/hw-transport/src/Transport.js
@@ -121,7 +121,7 @@ TransportStatusError.prototype = new Error();
  * it can be for instance an ID, an file path, a URL,...
  */
 export default class Transport<Descriptor> {
-  debug: ?(log: string) => void = null;
+  debug: ?(log: string) => void = global.__ledgerDebug || null;
   exchangeTimeout: number = 30000;
 
   /**

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -12,7 +12,7 @@
     "@ledgerhq/hw-app-xrp": "^4.23.0",
     "@ledgerhq/hw-transport-mocker": "^4.21.0",
     "@ledgerhq/hw-transport-node-hid": "^4.23.0",
-    "budo": "^11.3.2"
+    "budo": "^11.4.1"
   },
   "devDependencies": {
     "flow-bin": "^0.68.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2142,10 +2142,10 @@ bser@^2.0.0:
   dependencies:
     node-int64 "^0.4.0"
 
-budo@^11.3.2:
-  version "11.3.2"
-  resolved "https://registry.yarnpkg.com/budo/-/budo-11.3.2.tgz#ab943492cadbb0abaf9126b4c8c94eac2440adae"
-  integrity sha512-aXXaJf/5Kxvs7wXPMB/YVumeyyWZifaZCTOV3nvncLXmMxhHLVRjxG9umXwwdsx+gskRH+r/SU+ASAoKp6XN1A==
+budo@^11.4.1:
+  version "11.4.1"
+  resolved "https://registry.yarnpkg.com/budo/-/budo-11.4.1.tgz#e69185ec343051d9055af3880e3085d497041edb"
+  integrity sha512-TZMC0dYE3agNdVCuRCa7en16Cm3d0G0kLWObZ45tUQieIYdN1ARDOVBCnRxQXuj7NRjRsIunoxxiRSqqEPYDIQ==
   dependencies:
     bole "^2.0.0"
     browserify "^16.1.0"
@@ -4809,6 +4809,11 @@ events@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/events/-/events-2.0.0.tgz#cbbb56bf3ab1ac18d71c43bb32c86255062769f2"
   integrity sha512-r/M5YkNg9zwI8QbSf7tsDWWJvO3PGwZXyG7GpFAxtMASnHL2eblFd7iHiGPtyGKKFPZ59S63NeX10Ws6WqGDcg==
+
+events@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/events/-/events-3.0.0.tgz#9a0a0dfaf62893d92b875b8f2698ca4114973e88"
+  integrity sha512-Dc381HFWJzEOhQ+d8pkNon++bk9h6cdAoAj4iE6Q4y6xgTzySWXlKn05/TVNpjnfRqi/X0EpJEJohPjNI3zpVA==
 
 eventsource@0.1.6:
   version "0.1.6"


### PR DESCRIPTION
also add a way to hook to a global debug function, for debugging a production app purpose.

Fixes #222 