### PR TITLE
Ensure sequence is passed even with empty script when creating transaction

### DIFF
--- a/packages/hw-app-btc/src/Btc.js
+++ b/packages/hw-app-btc/src/Btc.js
@@ -160,6 +160,13 @@ export default class Btc {
         }
         offset += blockSize;
       }
+
+      // Handle case when no script length: we still want to pass the sequence
+      // relatable: https://github.com/LedgerHQ/ledger-live-desktop/issues/1386
+      if (script.length === 0) {
+        scriptBlocks.push(sequence);
+      }
+
       return eachSeries(scriptBlocks, scriptBlock =>
         this.getTrustedInputRaw(scriptBlock)
       );


### PR DESCRIPTION
This resolve (at least some) 0x6f01 error
relatable: https://github.com/LedgerHQ/ledger-live-desktop/issues/1386