### PR TITLE
Fix BTC "Fees: UNKNOWN" bug

### DIFF
--- a/packages/hw-app-btc/src/Btc.js
+++ b/packages/hw-app-btc/src/Btc.js
@@ -878,10 +878,10 @@ btc.signP2SHTransaction(
             0
           );
           trustedInputs.push({
-            trustedInput: false,
+            trustedInput: segwit ? false : true,
             value: segwit
               ? Buffer.from(trustedInput, "hex")
-              : Buffer.from(trustedInput, "hex").slice(4, 4 + 0x24),
+              : Buffer.from(trustedInput, "hex"),
             sequence
           });
         })


### PR DESCRIPTION
This PR applies the fix described in #232 .

**Warning**: Tests are failing.  
I assume because this patch changes the data passed to the device (as expected).   
I'm not comfortable changing the test vectors, but am submitting the PR as recommended by @gre 