### PR TITLE
Cleanup babel config

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,12 +25,10 @@
   "devDependencies": {
     "babel-cli": "^6.26.0",
     "babel-eslint": "^8.0.2",
-    "babel-plugin-transform-runtime": "^6.23.0",
     "babel-preset-env": "^1.7.0",
     "babel-preset-flow": "^6.23.0",
     "babel-preset-react": "^6.24.1",
     "babel-preset-stage-0": "^6.24.1",
-    "babel-runtime": "^6.26.0",
     "browserify": "^16.2.3",
     "create-hash": "^1.1.3",
     "documentation": "^6.1.0",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "rebuild": "lerna run clean && lerna run build",
     "publish": "yarn && lerna run clean && lerna run build && lerna publish --registry=https://registry.npmjs.org/"
   },
-  "dependencies": {
+  "devDependencies": {
     "babel-cli": "^6.26.0",
     "babel-eslint": "^8.0.2",
     "babel-plugin-transform-runtime": "^6.23.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1364,7 +1364,7 @@ babel-plugin-transform-regenerator@6.26.0, babel-plugin-transform-regenerator@^6
   dependencies:
     regenerator-transform "^0.10.0"
 
-babel-plugin-transform-runtime@6.23.0, babel-plugin-transform-runtime@^6.23.0:
+babel-plugin-transform-runtime@6.23.0:
   version "6.23.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-runtime/-/babel-plugin-transform-runtime-6.23.0.tgz#88490d446502ea9b8e7efb0fe09ec4d99479b1ee"
   integrity sha1-iEkNRGUC6puOfvsP4J7E2ZR5se4=


### PR DESCRIPTION
* After the [transform-runtime plugin was removed](https://github.com/LedgerHQ/ledgerjs/pull/228), we don't need the dependency anymore.
* There are no runtime dependencies for the lerna monorepo root; Move them to devDependencies to make this clear

I verified that there is no `require("babel-runtime)` in the libs/ output anymore, ~thus closes #211~ but all packages need a rebuild