### PR TITLE
add RSK derivation options

### DIFF
--- a/packages/web3-subprovider/src/index.js
+++ b/packages/web3-subprovider/src/index.js
@@ -5,7 +5,7 @@ import HookedWalletSubprovider from "web3-provider-engine/dist/es5/subproviders/
 import stripHexPrefix from "strip-hex-prefix";
 import EthereumTx from "ethereumjs-tx";
 
-const allowedHdPaths = ["44'/0'","44'/1'", "44'/60'", "44'/61'"];
+const allowedHdPaths = ["44'/0'", "44'/1'", "44'/60'", "44'/61'"];
 
 function makeError(msg, id) {
   const err = new Error(msg);

--- a/packages/web3-subprovider/src/index.js
+++ b/packages/web3-subprovider/src/index.js
@@ -5,7 +5,7 @@ import HookedWalletSubprovider from "web3-provider-engine/dist/es5/subproviders/
 import stripHexPrefix from "strip-hex-prefix";
 import EthereumTx from "ethereumjs-tx";
 
-const allowedHdPaths = ["44'/1'", "44'/60'", "44'/61'"];
+const allowedHdPaths = ["44'/0'","44'/1'", "44'/60'", "44'/61'"];
 
 function makeError(msg, id) {
   const err = new Error(msg);
@@ -16,7 +16,7 @@ function makeError(msg, id) {
 
 function obtainPathComponentsFromDerivationPath(derivationPath) {
   // check if derivation path follows 44'/60'/x'/n pattern
-  const regExp = /^(44'\/(?:1|60|61)'\/\d+'?\/)(\d+)$/;
+  const regExp = /^(44'\/(?:0|1|60|61)'\/\d+'?\/)(\d+)$/;
   const matchResult = regExp.exec(derivationPath);
   if (matchResult === null) {
     throw makeError(


### PR DESCRIPTION
In a similar spirit to https://github.com/trufflesuite/truffle-hdwallet-provider/pull/64. I was hoping to add the ability to derive RSK specific addresses from this sub-provider. RSK's [utility](https://utils.rsk.co/) mimics the derive path "44'/0'" with a process that matches[Ethereumjs-tx](https://github.com/ethereumjs/ethereumjs-tx) and  [Bip-39](https://iancoleman.io/bip39/) derivations when converting BTC private keys into RSK private keys as shown [here](https://utils.rsk.co/).