### PR TITLE
Allow unsignable inputs to be included in createPaymentTransactionNew

### DIFF
--- a/packages/hw-app-btc/src/Btc.js
+++ b/packages/hw-app-btc/src/Btc.js
@@ -715,15 +715,15 @@ btc.createPaymentTransactionNew(
                 value: Buffer.from(trustedInput, "hex"),
                 sequence
               });
-              let offset = useBip143 ? 0 : 4
+              let offset = useBip143 ? 0 : 4;
               targetTransaction.inputs.push({
-                prevout: Buffer.from(trustedInput, 'hex').slice(offset, offset + 0x24),
+                prevout: Buffer.from(trustedInput, "hex").slice(offset, offset + 0x24),
                 script: Buffer.alloc(0),
                 sequence
-              })
+              });
             })
-          )
-        })
+          );
+        });
       })
       .then(() =>
         doIf(!resuming, () =>
@@ -789,7 +789,7 @@ btc.createPaymentTransactionNew(
                       Buffer.from([OP_EQUALVERIFY, OP_CHECKSIG])
                     ]);
           } else {
-            script = Buffer.alloc(0)
+            script = Buffer.alloc(0);
           }
           let pseudoTX = Object.assign({}, targetTransaction);
           let pseudoTrustedInputs = useBip143
@@ -823,9 +823,9 @@ btc.createPaymentTransactionNew(
                   lockTime,
                   sigHashType,
                   expiryHeight
-                )
+                );
               } else {
-                return false
+                return false;
               }
             })
             .then(signature => {

--- a/packages/hw-app-btc/src/Btc.js
+++ b/packages/hw-app-btc/src/Btc.js
@@ -702,7 +702,7 @@ btc.createPaymentTransactionNew(
       .then(() => {
         return foreach(multisigInputs, input => {
           return doIf(!resuming, () =>
-            getTrustedInputCall(input[1], input[0]).then(trustedInput => {
+            getTrustedInputCall(input[1], input[0], additionals).then(trustedInput => {
               let sequence = Buffer.alloc(4);
               sequence.writeUInt32LE(
                 input.length >= 4 && typeof input[3] === "number"

--- a/packages/hw-app-btc/src/Btc.js
+++ b/packages/hw-app-btc/src/Btc.js
@@ -569,6 +569,7 @@ export default class Btc {
    * - "bipxxx" for using BIPxxx
    * - "sapling" to indicate a zec transaction is supporting sapling (to be set over block 419200)
    * @param expiryHeight is an optional Buffer for zec overwinter / sapling Txs
+   * @param multisigInputs is an optional array of [ transaction, output_index ] that cannot be signed by the device
    * @return the signed transaction ready to be broadcast
    * @example
 btc.createPaymentTransactionNew(
@@ -588,7 +589,8 @@ btc.createPaymentTransactionNew(
     segwit?: boolean = false,
     initialTimestamp?: number,
     additionals: Array<string> = [],
-    expiryHeight?: Buffer
+    expiryHeight?: Buffer,
+    multisigInputs?: Array<[Transaction, number]>=[]
   ) {
     const isDecred = additionals.includes("decred");
     const hasTimestamp = initialTimestamp !== undefined;
@@ -697,6 +699,32 @@ btc.createPaymentTransactionNew(
           });
         }
       })
+      .then(() => {
+        return foreach(multisigInputs, input => {
+          return doIf(!resuming, () =>
+            getTrustedInputCall(input[1], input[0]).then(trustedInput => {
+              let sequence = Buffer.alloc(4);
+              sequence.writeUInt32LE(
+                input.length >= 4 && typeof input[3] === "number"
+                  ? input[3]
+                  : DEFAULT_SEQUENCE,
+                0
+              );
+              trustedInputs.push({
+                trustedInput: false,
+                value: Buffer.from(trustedInput, "hex"),
+                sequence
+              });
+              let offset = useBip143 ? 0 : 4
+              targetTransaction.inputs.push({
+                prevout: Buffer.from(trustedInput, 'hex').slice(offset, offset + 0x24),
+                script: Buffer.alloc(0),
+                sequence
+              })
+            })
+          )
+        })
+      })
       .then(() =>
         doIf(!resuming, () =>
           // Collect public keys
@@ -747,17 +775,22 @@ btc.createPaymentTransactionNew(
       )
       .then(() =>
         // Do the second run with the individual transaction
-        foreach(inputs, (input, i) => {
-          let script =
-            inputs[i].length >= 3 && typeof inputs[i][2] === "string"
-              ? Buffer.from(inputs[i][2], "hex")
-              : !segwit
-                ? regularOutputs[i].script
-                : Buffer.concat([
-                    Buffer.from([OP_DUP, OP_HASH160, HASH_SIZE]),
-                    this.hashPublicKey(publicKeys[i]),
-                    Buffer.from([OP_EQUALVERIFY, OP_CHECKSIG])
-                  ]);
+        foreach(inputs.concat(multisigInputs), (input, i) => {
+          let script;
+          if (inputs[i]) {
+            script =
+              inputs[i].length >= 3 && typeof inputs[i][2] === "string"
+                ? Buffer.from(inputs[i][2], "hex")
+                : !segwit
+                  ? regularOutputs[i].script
+                  : Buffer.concat([
+                      Buffer.from([OP_DUP, OP_HASH160, HASH_SIZE]),
+                      this.hashPublicKey(publicKeys[i]),
+                      Buffer.from([OP_EQUALVERIFY, OP_CHECKSIG])
+                    ]);
+          } else {
+            script = Buffer.alloc(0)
+          }
           let pseudoTX = Object.assign({}, targetTransaction);
           let pseudoTrustedInputs = useBip143
             ? [trustedInputs[i]]
@@ -784,19 +817,24 @@ btc.createPaymentTransactionNew(
               )
             )
             .then(() => {
-              return this.signTransaction(
-                associatedKeysets[i],
-                lockTime,
-                sigHashType,
-                expiryHeight,
-                additionals
-              );
+              if (associatedKeysets[i]) {
+                return this.signTransaction(
+                  associatedKeysets[i],
+                  lockTime,
+                  sigHashType,
+                  expiryHeight
+                )
+              } else {
+                return false
+              }
             })
             .then(signature => {
-              signatures.push(signature);
-              targetTransaction.inputs[i].script = nullScript;
-              if (firstRun) {
-                firstRun = false;
+              if (signature) {
+                signatures.push(signature);
+                targetTransaction.inputs[i].script = nullScript;
+                if (firstRun) {
+                  firstRun = false;
+                }
               }
             });
         })

--- a/packages/hw-app-btc/src/Btc.js
+++ b/packages/hw-app-btc/src/Btc.js
@@ -590,7 +590,7 @@ btc.createPaymentTransactionNew(
     initialTimestamp?: number,
     additionals: Array<string> = [],
     expiryHeight?: Buffer,
-    multisigInputs?: Array<[Transaction, number]>=[]
+    multisigInputs?: Array<[Transaction, number, ?string, ?number]> = []
   ) {
     const isDecred = additionals.includes("decred");
     const hasTimestamp = initialTimestamp !== undefined;


### PR DESCRIPTION
Due to some network forks not providing replay protection it is vital to allow users to split their coins so they can be used on either chain. If user includes coin dust from one chain in part of their transaction, it cannot be used on the other forked chain.

This PR allows the client to pass an additional array of inputs that can be signed by another service, but not the device.