### PR TITLE
Fix decred: getVarInt error

### DIFF
--- a/packages/hw-app-btc/src/Btc.js
+++ b/packages/hw-app-btc/src/Btc.js
@@ -1107,12 +1107,25 @@ const tx1 = btc.splitTransaction("01000000014ea60aeac5252c14291d428915bd7ccd1bfc
     const numberInputs = varint[0];
     offset += varint[1];
     for (let i = 0; i < numberInputs; i++) {
-      const prevout = transaction.slice(offset, offset + 36);
-      offset += 36;
-      varint = this.getVarint(transaction, offset);
-      offset += varint[1];
-      const script = transaction.slice(offset, offset + varint[0]);
-      offset += varint[0];
+      let prevout = transaction.slice(offset, offset + 32);
+      offset += 32;
+      //Tree field
+      if (isDecred) {
+        offset += 1;
+      }
+      const prevOutIndex = transaction.slice(offset, offset + 4);
+      offset += 4;
+      prevout = Buffer.concat([prevout, prevOutIndex]);
+
+      let script;
+      //No script for decred, it has a witness
+      if (!isDecred) {
+        varint = this.getVarint(transaction, offset);
+        offset += varint[1];
+        script = transaction.slice(offset, offset + varint[0]);
+        offset += varint[0];
+      }
+
       const sequence = transaction.slice(offset, offset + 4);
       offset += 4;
       inputs.push({ prevout, script, sequence });


### PR DESCRIPTION
**Fix**
We were so lucky that it was working before :trollface: , basically inputs were wrongly parsed for decred, two mistakes we were making:

- no parsing of tree field: one byte between prev tx hash and prev index,
- parsing script field which does not exist for Decred,

**Analysis**
It went through QA because we were lucky, the two errors above were canceling each other in our tests, e.g. this raw input`cb1ecbdbe9b7194f65a70482e42389dbab645af7ff141c80ea5b64c17b82862f0100000000ffffffff` was parsed to : `prevOut = cb1ecbdbe9b7194f65a70482e42389dbab645af7ff141c80ea5b64c17b82862f01000000
` (which is presumed to be prevOutHash + prevOutIndex)
`scriptLength=00`and `sequence=ffffffff`, but this should be parsed as: `prevOutHash = cb1ecbdbe9b7194f65a70482e42389dbab645af7ff141c80ea5b64c17b82862f`, `treeField=01`, `prevOutIndex=00000000` and `sequence=ffffffff` (no script for decred)

To sum up, we were safe when `prevOutIndex == 00000000` :trollface: 
