### PR TITLE
Revert PR of multisigInputs feature

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -3,7 +3,7 @@
   "packages": [
     "packages/*"
   ],
-  "version": "4.33.6",
+  "version": "4.33.7",
   "npmClient": "yarn",
   "useWorkspaces": true
 }

--- a/package.json
+++ b/package.json
@@ -22,15 +22,13 @@
     "rebuild": "lerna run clean && lerna run build",
     "publish": "yarn && lerna run clean && lerna run build && lerna publish --registry=https://registry.npmjs.org/"
   },
-  "dependencies": {
+  "devDependencies": {
     "babel-cli": "^6.26.0",
     "babel-eslint": "^8.0.2",
-    "babel-plugin-transform-runtime": "^6.23.0",
     "babel-preset-env": "^1.7.0",
     "babel-preset-flow": "^6.23.0",
     "babel-preset-react": "^6.24.1",
     "babel-preset-stage-0": "^6.24.1",
-    "babel-runtime": "^6.26.0",
     "browserify": "^16.2.3",
     "create-hash": "^1.1.3",
     "documentation": "^6.1.0",

--- a/packages/errors/.flowconfig
+++ b/packages/errors/.flowconfig
@@ -1,0 +1,13 @@
+[ignore]
+<PROJECT_ROOT>/lib
+
+[include]
+
+[libs]
+flow-typed
+
+[lints]
+
+[options]
+
+[strict]

--- a/packages/errors/README.md
+++ b/packages/errors/README.md
@@ -1,0 +1,5 @@
+<img src="https://user-images.githubusercontent.com/211411/34776833-6f1ef4da-f618-11e7-8b13-f0697901d6a8.png" height="100" />
+
+## @ledgerhq/errors
+
+Hodl all possible errors of Ledger (live, ledgerjs) so we can deal with them in a unified way (share between libraries, `instanceof` them,...)

--- a/packages/errors/package.json
+++ b/packages/errors/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "@ledgerhq/errors",
+  "version": "4.32.0",
+  "description": "Ledger Hardware Wallet common interface of the communication layer",
+  "keywords": [
+    "Ledger",
+    "LedgerWallet",
+    "NanoS",
+    "Blue",
+    "Hardware Wallet"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/LedgerHQ/ledgerjs"
+  },
+  "bugs": {
+    "url": "https://github.com/LedgerHQ/ledgerjs/issues"
+  },
+  "homepage": "https://github.com/LedgerHQ/ledgerjs",
+  "publishConfig": {
+    "access": "public"
+  },
+  "main": "lib/index.js",
+  "license": "Apache-2.0",
+  "dependencies": {
+  },
+  "devDependencies": {
+    "flow-bin": "^0.68.0",
+    "flow-typed": "^2.4.0"
+  },
+  "scripts": {
+    "flow": "flow",
+    "clean": "bash ../../script/clean.sh",
+    "build": "bash ../../script/build.sh",
+    "watch": "bash ../../script/watch.sh"
+  }
+}

--- a/packages/errors/package.json
+++ b/packages/errors/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ledgerhq/errors",
-  "version": "4.32.0",
+  "version": "4.33.7",
   "description": "Ledger common errors",
   "keywords": [
     "Ledger"
@@ -18,8 +18,6 @@
   },
   "main": "lib/index.js",
   "license": "Apache-2.0",
-  "dependencies": {
-  },
   "devDependencies": {
     "flow-bin": "^0.68.0",
     "flow-typed": "^2.4.0"

--- a/packages/errors/package.json
+++ b/packages/errors/package.json
@@ -1,13 +1,9 @@
 {
   "name": "@ledgerhq/errors",
   "version": "4.32.0",
-  "description": "Ledger Hardware Wallet common interface of the communication layer",
+  "description": "Ledger common errors",
   "keywords": [
-    "Ledger",
-    "LedgerWallet",
-    "NanoS",
-    "Blue",
-    "Hardware Wallet"
+    "Ledger"
   ],
   "repository": {
     "type": "git",

--- a/packages/errors/src/helpers.js
+++ b/packages/errors/src/helpers.js
@@ -1,0 +1,97 @@
+// @flow
+/* eslint-disable no-continue */
+/* eslint-disable no-param-reassign */
+/* eslint-disable no-prototype-builtins */
+
+const errorClasses = {};
+
+export const createCustomErrorClass = (name: string): Class<any> => {
+  const C = function CustomError(message?: string, fields?: Object) {
+    Object.assign(this, fields);
+    this.name = name;
+    this.message = message || name;
+    this.stack = new Error().stack;
+  };
+  // $FlowFixMe
+  C.prototype = new Error();
+
+  errorClasses[name] = C;
+  // $FlowFixMe we can't easily type a subset of Error for now...
+  return C;
+};
+
+// inspired from https://github.com/programble/errio/blob/master/index.js
+export const deserializeError = (object: mixed): Error => {
+  if (typeof object === "object" && object) {
+    try {
+      // $FlowFixMe FIXME HACK
+      const msg = JSON.parse(object.message);
+      if (msg.message && msg.name) {
+        object = msg;
+      }
+    } catch (e) {
+      // nothing
+    }
+    const constructor =
+      object.name === "Error"
+        ? Error
+        : typeof object.name === "string"
+          ? errorClasses[object.name] || createCustomErrorClass(object.name)
+          : Error;
+
+    const error = Object.create(constructor.prototype);
+    for (const prop in object) {
+      if (object.hasOwnProperty(prop)) {
+        error[prop] = object[prop];
+      }
+    }
+    if (!error.stack && Error.captureStackTrace) {
+      Error.captureStackTrace(error, deserializeError);
+    }
+    return error;
+  }
+  return new Error(String(object));
+};
+
+// inspired from https://github.com/sindresorhus/serialize-error/blob/master/index.js
+export const serializeError = (value: mixed) => {
+  if (!value) return value;
+  if (typeof value === "object") {
+    return destroyCircular(value, []);
+  }
+  if (typeof value === "function") {
+    return `[Function: ${value.name || "anonymous"}]`;
+  }
+  return value;
+};
+
+// https://www.npmjs.com/package/destroy-circular
+function destroyCircular(from: Object, seen) {
+  const to = {};
+  seen.push(from);
+  for (const key of Object.keys(from)) {
+    const value = from[key];
+    if (typeof value === "function") {
+      continue;
+    }
+    if (!value || typeof value !== "object") {
+      to[key] = value;
+      continue;
+    }
+    if (seen.indexOf(from[key]) === -1) {
+      to[key] = destroyCircular(from[key], seen.slice(0));
+      continue;
+    }
+    to[key] = "[Circular]";
+  }
+  if (typeof from.name === "string") {
+    to.name = from.name;
+  }
+  if (typeof from.message === "string") {
+    to.message = from.message;
+  }
+  if (typeof from.stack === "string") {
+    to.stack = from.stack;
+  }
+  return to;
+}

--- a/packages/errors/src/index.js
+++ b/packages/errors/src/index.js
@@ -1,0 +1,101 @@
+// @flow
+
+import { createCustomErrorClass } from "./helpers";
+
+export const AccountNameRequiredError = createCustomErrorClass(
+  "AccountNameRequired"
+);
+export const BluetoothRequired = createCustomErrorClass("BluetoothRequired");
+export const BtcUnmatchedApp = createCustomErrorClass("BtcUnmatchedApp");
+export const CantOpenDevice = createCustomErrorClass("CantOpenDevice");
+export const DeviceAppVerifyNotSupported = createCustomErrorClass(
+  "DeviceAppVerifyNotSupported"
+);
+export const DeviceGenuineSocketEarlyClose = createCustomErrorClass(
+  "DeviceGenuineSocketEarlyClose"
+);
+export const DeviceNotGenuineError = createCustomErrorClass("DeviceNotGenuine");
+export const DeviceOnDashboardExpected = createCustomErrorClass(
+  "DeviceOnDashboardExpected"
+);
+export const DeviceSocketFail = createCustomErrorClass("DeviceSocketFail");
+export const DeviceSocketNoBulkStatus = createCustomErrorClass(
+  "DeviceSocketNoBulkStatus"
+);
+export const DisconnectedDevice = createCustomErrorClass("DisconnectedDevice");
+export const EnpointConfigError = createCustomErrorClass("EnpointConfig");
+export const FeeEstimationFailed = createCustomErrorClass(
+  "FeeEstimationFailed"
+);
+export const HardResetFail = createCustomErrorClass("HardResetFail");
+export const InvalidAddress = createCustomErrorClass("InvalidAddress");
+export const LatestMCUInstalledError = createCustomErrorClass(
+  "LatestMCUInstalledError"
+);
+export const UnknownMCU = createCustomErrorClass("UnknownMCU");
+export const LedgerAPIError = createCustomErrorClass("LedgerAPIError");
+export const LedgerAPIErrorWithMessage = createCustomErrorClass(
+  "LedgerAPIErrorWithMessage"
+);
+export const LedgerAPINotAvailable = createCustomErrorClass(
+  "LedgerAPINotAvailable"
+);
+export const ManagerAppAlreadyInstalledError = createCustomErrorClass(
+  "ManagerAppAlreadyInstalled"
+);
+export const ManagerAppRelyOnBTCError = createCustomErrorClass(
+  "ManagerAppRelyOnBTC"
+);
+export const ManagerDeviceLockedError = createCustomErrorClass(
+  "ManagerDeviceLocked"
+);
+export const ManagerNotEnoughSpaceError = createCustomErrorClass(
+  "ManagerNotEnoughSpace"
+);
+export const ManagerUninstallBTCDep = createCustomErrorClass(
+  "ManagerUninstallBTCDep"
+);
+export const NetworkDown = createCustomErrorClass("NetworkDown");
+export const NoAddressesFound = createCustomErrorClass("NoAddressesFound");
+export const NotEnoughBalance = createCustomErrorClass("NotEnoughBalance");
+export const NotEnoughBalanceBecauseDestinationNotCreated = createCustomErrorClass(
+  "NotEnoughBalanceBecauseDestinationNotCreated"
+);
+export const PasswordsDontMatchError = createCustomErrorClass(
+  "PasswordsDontMatch"
+);
+export const PasswordIncorrectError = createCustomErrorClass(
+  "PasswordIncorrect"
+);
+export const TimeoutTagged = createCustomErrorClass("TimeoutTagged");
+export const UnexpectedBootloader = createCustomErrorClass(
+  "UnexpectedBootloader"
+);
+export const UpdateYourApp = createCustomErrorClass("UpdateYourApp");
+export const UserRefusedAddress = createCustomErrorClass("UserRefusedAddress");
+export const UserRefusedFirmwareUpdate = createCustomErrorClass(
+  "UserRefusedFirmwareUpdate"
+);
+export const UserRefusedOnDevice = createCustomErrorClass(
+  "UserRefusedOnDevice"
+); // TODO rename because it's just for transaction refusal
+export const WebsocketConnectionError = createCustomErrorClass(
+  "WebsocketConnectionError"
+);
+export const WebsocketConnectionFailed = createCustomErrorClass(
+  "WebsocketConnectionFailed"
+);
+export const WrongDeviceForAccount = createCustomErrorClass(
+  "WrongDeviceForAccount"
+);
+export const ETHAddressNonEIP = createCustomErrorClass("ETHAddressNonEIP");
+export const CantScanQRCode = createCustomErrorClass("CantScanQRCode");
+export const FeeNotLoaded = createCustomErrorClass("FeeNotLoaded");
+export const SyncError = createCustomErrorClass("SyncError");
+export const PairingFailed = createCustomErrorClass("PairingFailed");
+export const GenuineCheckFailed = createCustomErrorClass("GenuineCheckFailed");
+
+// db stuff, no need to translate
+export const NoDBPathGiven = createCustomErrorClass("NoDBPathGiven");
+export const DBWrongPassword = createCustomErrorClass("DBWrongPassword");
+export const DBNotReset = createCustomErrorClass("DBNotReset");

--- a/packages/example-browser/package.json
+++ b/packages/example-browser/package.json
@@ -6,7 +6,7 @@
     "build": "cross-env NODE_ENV=production parcel build index.html --no-minify --public-url /"
   },
   "dependencies": {
-    "@ledgerhq/hw-app-btc": "^4.33.6",
+    "@ledgerhq/hw-app-btc": "^4.33.7",
     "@ledgerhq/hw-app-eth": "^4.32.0",
     "@ledgerhq/hw-transport-u2f": "^4.32.0",
     "react": "^16.5.2",
@@ -19,5 +19,5 @@
     "parcel-bundler": "^1.6.2"
   },
   "private": true,
-  "version": "4.33.6"
+  "version": "4.33.7"
 }

--- a/packages/example-node/package.json
+++ b/packages/example-node/package.json
@@ -1,11 +1,11 @@
 {
   "private": true,
   "name": "@ledgerhq/example-node",
-  "version": "4.33.6",
+  "version": "4.33.7",
   "main": "index.js",
   "license": "Apache-2.0",
   "dependencies": {
-    "@ledgerhq/hw-app-btc": "^4.33.6",
+    "@ledgerhq/hw-app-btc": "^4.33.7",
     "@ledgerhq/hw-app-eth": "^4.32.0",
     "@ledgerhq/hw-transport-node-hid": "^4.33.3"
   },

--- a/packages/hw-app-btc/package.json
+++ b/packages/hw-app-btc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ledgerhq/hw-app-btc",
-  "version": "4.33.6",
+  "version": "4.33.7",
   "description": "Ledger Hardware Wallet Bitcoin Application API",
   "keywords": [
     "Ledger",

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -1,12 +1,12 @@
 {
   "private": true,
   "name": "@ledgerhq/test",
-  "version": "4.33.6",
+  "version": "4.33.7",
   "main": "index.js",
   "license": "Apache-2.0",
   "dependencies": {
     "@ledgerhq/hw-app-ada": "^4.33.3",
-    "@ledgerhq/hw-app-btc": "^4.33.6",
+    "@ledgerhq/hw-app-btc": "^4.33.7",
     "@ledgerhq/hw-app-eth": "^4.32.0",
     "@ledgerhq/hw-app-str": "^4.32.0",
     "@ledgerhq/hw-app-xrp": "^4.32.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1386,7 +1386,7 @@ babel-plugin-transform-regenerator@6.26.0, babel-plugin-transform-regenerator@^6
   dependencies:
     regenerator-transform "^0.10.0"
 
-babel-plugin-transform-runtime@6.23.0, babel-plugin-transform-runtime@^6.23.0:
+babel-plugin-transform-runtime@6.23.0:
   version "6.23.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-runtime/-/babel-plugin-transform-runtime-6.23.0.tgz#88490d446502ea9b8e7efb0fe09ec4d99479b1ee"
   integrity sha1-iEkNRGUC6puOfvsP4J7E2ZR5se4=


### PR DESCRIPTION
This PR reverts commits a843a7a9f4 ... ac0e3bb15c related to multisigInputs feature which was causing errors in Live when signing bitcoin like transactions (error `Invalid Data 0x6f...`)
It includes also fix of Decred that was failing at broadcast because of oprhan transactions, bug was occurring when creating getting trusted inputs: streamed data was wrong, `tree` field was incorrect