### PR TITLE
Revert PR of multisigInputs feature

### DIFF
--- a/packages/hw-app-btc/src/Btc.js
+++ b/packages/hw-app-btc/src/Btc.js
@@ -178,9 +178,10 @@ export default class Btc {
 
     const processInputs = () => {
       return eachSeries(inputs, input => {
+        const treeField = isDecred ? (input.tree || Buffer.from([0x00])) : Buffer.alloc(0);
         const data = Buffer.concat([
           input.prevout,
-          isDecred ? Buffer.from([0x00]) : Buffer.alloc(0), //tree
+          treeField,
           this.createVarint(input.script.length)
         ]);
         return this.getTrustedInputRaw(data).then(() => {
@@ -1151,28 +1152,25 @@ const tx1 = btc.splitTransaction("01000000014ea60aeac5252c14291d428915bd7ccd1bfc
     const numberInputs = varint[0];
     offset += varint[1];
     for (let i = 0; i < numberInputs; i++) {
-      let prevout = transaction.slice(offset, offset + 32);
-      offset += 32;
-      //Tree field
-      if (isDecred) {
-        offset += 1;
-      }
-      const prevOutIndex = transaction.slice(offset, offset + 4);
-      offset += 4;
-      prevout = Buffer.concat([prevout, prevOutIndex]);
-
+      const prevout = transaction.slice(offset, offset + 36);
+      offset += 36;
       let script = Buffer.alloc(0);
+      let tree = Buffer.alloc(0);
       //No script for decred, it has a witness
       if (!isDecred) {
         varint = this.getVarint(transaction, offset);
         offset += varint[1];
         script = transaction.slice(offset, offset + varint[0]);
         offset += varint[0];
+      } else {
+        //Tree field
+        tree = transaction.slice(offset, offset + 1);
+        offset += 1;
       }
 
       const sequence = transaction.slice(offset, offset + 4);
       offset += 4;
-      inputs.push({ prevout, script, sequence });
+      inputs.push({ prevout, script, sequence, tree });
     }
     varint = this.getVarint(transaction, offset);
     const numberOutputs = varint[0];
@@ -1350,7 +1348,8 @@ const outputScript = btc.serializeTransactionOutputs(tx1).toString('hex');
 type TransactionInput = {
   prevout: Buffer,
   script: Buffer,
-  sequence: Buffer
+  sequence: Buffer,
+  tree?: Buffer
 };
 
 /**


### PR DESCRIPTION
This PR reverts commits ac0e3bb15c related to multisigInputs feature which was causing errors in Live when signing bitcoin like transactions (error Invalid Data 0x6f...)

It includes also fix of Decred that was failing at broadcast because of orphan transactions, bug was occurring when creating getting trusted inputs: streamed data was wrong, tree field was incorrect