### PR TITLE
LL-898 Added error for cryptos not supporting source===destination

### DIFF
--- a/packages/errors/src/index.js
+++ b/packages/errors/src/index.js
@@ -29,6 +29,9 @@ export const FeeEstimationFailed = createCustomErrorClass(
 );
 export const HardResetFail = createCustomErrorClass("HardResetFail");
 export const InvalidAddress = createCustomErrorClass("InvalidAddress");
+export const InvalidAddressBecauseDestinationIsAlsoSource = createCustomErrorClass(
+  "InvalidAddressBecauseDestinationIsAlsoSource"
+);
 export const LatestMCUInstalledError = createCustomErrorClass(
   "LatestMCUInstalledError"
 );


### PR DESCRIPTION
Needed for LL-898 for currencies not supporting sending funds to the origin account such as xrp