### PR TITLE
LL-1086 Broadcast connect/disconnect events from react-native-hid

### DIFF
--- a/packages/errors/src/index.js
+++ b/packages/errors/src/index.js
@@ -18,6 +18,7 @@ export const DeviceNotGenuineError = createCustomErrorClass("DeviceNotGenuine");
 export const DeviceOnDashboardExpected = createCustomErrorClass(
   "DeviceOnDashboardExpected"
 );
+export const DeviceNameInvalid = createCustomErrorClass("DeviceNameInvalid");
 export const DeviceSocketFail = createCustomErrorClass("DeviceSocketFail");
 export const DeviceSocketNoBulkStatus = createCustomErrorClass(
   "DeviceSocketNoBulkStatus"

--- a/packages/react-native-hid/android/src/main/java/com/ledgerwallet/hid/ReactHIDModule.java
+++ b/packages/react-native-hid/android/src/main/java/com/ledgerwallet/hid/ReactHIDModule.java
@@ -15,6 +15,7 @@ import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
+import com.facebook.react.modules.core.DeviceEventManagerModule;
 import com.facebook.react.bridge.ReactMethod;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.WritableArray;
@@ -29,14 +30,57 @@ import java.util.UUID;
 public class ReactHIDModule extends ReactContextBaseJavaModule {
 
     private final HashMap<String, HIDDevice> hidDevices = new HashMap<>();
+    private static final String ACTION_USB_ATTACHED  = "android.hardware.usb.action.USB_DEVICE_ATTACHED";
+    private static final String ACTION_USB_DETACHED  = "android.hardware.usb.action.USB_DEVICE_DETACHED";
+    private static final String ACTION_USB_PERMISSION = "com.ledgerwallet.hid.USB_PERMISSION";
+
+    private BroadcastReceiver receiver;
 
     public ReactHIDModule(ReactApplicationContext reactContext) {
         super(reactContext);
+        setDeviceConnectionReceiver();
     }
 
     @Override
     public String getName() {
         return "HID";
+    }
+
+    private void setDeviceConnectionReceiver(){
+        IntentFilter filter = new IntentFilter();
+        filter.addAction(ACTION_USB_ATTACHED);
+        filter.addAction(ACTION_USB_DETACHED);
+
+        receiver = new BroadcastReceiver() {
+            @Override
+            public void onReceive(Context  context, Intent intent) {
+                switch (intent.getAction()) {
+                    case ACTION_USB_ATTACHED:
+
+                    UsbDevice device = (UsbDevice) intent.getExtras().get(UsbManager.EXTRA_DEVICE);
+                    getReactApplicationContext()
+                            .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class)
+                            .emit("onDeviceConnect", buildMapFromDevice(device));
+                        break;
+                    case ACTION_USB_DETACHED:
+                        getReactApplicationContext()
+                                .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class)
+                                .emit("onDeviceDisconnect", null);
+                        break;
+                }
+            }
+        };
+        getReactApplicationContext().registerReceiver(receiver, filter);
+    }
+
+    private WritableMap buildMapFromDevice(UsbDevice device){
+        WritableMap map = Arguments.createMap();
+        map.putString("name", device.getDeviceName());
+        map.putInt("deviceId", device.getDeviceId());
+        map.putInt("productId", device.getProductId());
+        map.putInt("vendorId", device.getVendorId());
+        map.putString("deviceName", device.getDeviceName());
+        return map;
     }
 
     @ReactMethod
@@ -46,13 +90,7 @@ public class ReactHIDModule extends ReactContextBaseJavaModule {
         WritableArray deviceArray = Arguments.createArray();
         for (String key : usbDevices.keySet()) {
             UsbDevice device = usbDevices.get(key);
-            WritableMap map = Arguments.createMap();
-            map.putString("name", device.getDeviceName());
-            map.putInt("deviceId", device.getDeviceId());
-            map.putInt("productId", device.getProductId());
-            map.putInt("vendorId", device.getVendorId());
-            map.putString("deviceName", device.getDeviceName());
-            deviceArray.pushMap(map);
+            deviceArray.pushMap(buildMapFromDevice(device));
         }
         p.resolve(deviceArray);
     }
@@ -154,7 +192,6 @@ public class ReactHIDModule extends ReactContextBaseJavaModule {
         return map;
     }
 
-    private static final String ACTION_USB_PERMISSION = "com.ledgerwallet.hid.USB_PERMISSION";
 
     private UsbManager getUsbManager() {
         ReactApplicationContext rAppContext = getReactApplicationContext();

--- a/packages/react-native-hid/android/src/main/java/com/ledgerwallet/hid/ReactHIDModule.java
+++ b/packages/react-native-hid/android/src/main/java/com/ledgerwallet/hid/ReactHIDModule.java
@@ -54,20 +54,11 @@ public class ReactHIDModule extends ReactContextBaseJavaModule {
         receiver = new BroadcastReceiver() {
             @Override
             public void onReceive(Context  context, Intent intent) {
-                switch (intent.getAction()) {
-                    case ACTION_USB_ATTACHED:
-
-                    UsbDevice device = (UsbDevice) intent.getExtras().get(UsbManager.EXTRA_DEVICE);
-                    getReactApplicationContext()
-                            .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class)
-                            .emit("onDeviceConnect", buildMapFromDevice(device));
-                        break;
-                    case ACTION_USB_DETACHED:
-                        getReactApplicationContext()
-                                .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class)
-                                .emit("onDeviceDisconnect", null);
-                        break;
-                }
+                String event = intent.getAction().equals(ACTION_USB_ATTACHED)?"onDeviceConnect":"onDeviceDisconnect";
+                UsbDevice device = (UsbDevice) intent.getExtras().get(UsbManager.EXTRA_DEVICE);
+                getReactApplicationContext()
+                        .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class)
+                        .emit(event, buildMapFromDevice(device));
             }
         };
         getReactApplicationContext().registerReceiver(receiver, filter);

--- a/packages/react-native-hid/src/index.js
+++ b/packages/react-native-hid/src/index.js
@@ -19,10 +19,10 @@ export default class HIDTransport extends Transport<DeviceObj> {
     this.id = id;
   }
 
-  static onDeviceConnect = device => {
-    if (HIDTransport.observer && !HIDTransport.unsubscribed) {
+  static onDeviceConnect = (device: *) => {
+    if (!HIDTransport.unsubscribed) {
       const deviceModel = identifyUSBProductId(device.productId);
-      HIDTransport.observer.next({
+      HIDTransport.observer && HIDTransport.observer.next({
         type: "add",
         descriptor: device,
         deviceModel
@@ -30,7 +30,7 @@ export default class HIDTransport extends Transport<DeviceObj> {
     }
   };
 
-  static onDeviceDisconnect = event => {
+  static onDeviceDisconnect = (_: *) => {
     if (HIDTransport.observer && !HIDTransport.unsubscribed) {
       HIDTransport.observer.next({ type: "reset" });
       HIDTransport.listDevices();
@@ -50,10 +50,8 @@ export default class HIDTransport extends Transport<DeviceObj> {
     HIDTransport.list().then(candidates => {
       for (const c of candidates) {
         if (!HIDTransport.unsubscribed) {
-          console.log("wadus device listed",c)
           const deviceModel = identifyUSBProductId(c.productId);
-          console.log("wadus device detected model", deviceModel)
-          HIDTransport.observer.next({ type: "add", descriptor: c, deviceModel });
+          HIDTransport.observer && HIDTransport.observer.next({ type: "add", descriptor: c, deviceModel });
         }
       }
     });


### PR DESCRIPTION
This listens to devices being plugged in/out of the phone and broadcasts the event. 

~~Since we don't have a unique identifier to selectively remove a device from the list I've added the `reset` event, which is not handled perfectly (it adds some stuff) from live-common but doesn't affect the functionality. Also, need to handle that `reset` on mobile end to delete the list of devices added since we retrigger the list.~~

We merge an initial list of connected devices with a subject that will emit subsequent connections and disconnects, this eliminates the need to unsubscribe and support multiple instances of the device selector running at the same time, with all receiving the broadcasted events.