### PR TITLE
Remove useless minSdk in AndroidManifest.xml

### DIFF
--- a/packages/react-native-hid/android/src/main/AndroidManifest.xml
+++ b/packages/react-native-hid/android/src/main/AndroidManifest.xml
@@ -1,5 +1,4 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.ledgerwallet.hid">
     <uses-feature android:name="android.hardware.usb.host" android:required="false"/>
-    <uses-sdk android:minSdkVersion="12" />
 </manifest>


### PR DESCRIPTION
Remove useless (and now breaking) minSdk in AndroidManifest.xml