### PR TITLE
WebUSB: only request() if no device found + detect disconnect

### DIFF
--- a/packages/hw-transport-webusb/README.md
+++ b/packages/hw-transport-webusb/README.md
@@ -27,6 +27,8 @@ Important: The transport functions `create()` and `listen()` must be in the cont
     -   [list](#list)
     -   [listen](#listen)
         -   [Parameters](#parameters-2)
+    -   [request](#request)
+    -   [openConnected](#openconnected)
     -   [open](#open)
         -   [Parameters](#parameters-3)
 
@@ -70,11 +72,12 @@ Check if WebUSB transport is supported.
 
 #### list
 
-List the WebUSB devices that was previously authorized.
+List the WebUSB devices that was previously authorized by the user.
 
 #### listen
 
-Actively listen to WebUSB devices and emit ONE device that was selected by the native permission UI.
+Actively listen to WebUSB devices and emit ONE device
+that was either accepted before, if not it will trigger the native permission UI.
 
 Important: it must be called in the context of a UI click!
 
@@ -83,6 +86,14 @@ Important: it must be called in the context of a UI click!
 -   `observer` **Observer&lt;DescriptorEvent&lt;USBDevice>>** 
 
 Returns **Subscription** 
+
+#### request
+
+Similar to create() except it will always display the device permission (even if some devices are already accepted).
+
+#### openConnected
+
+Similar to create() except it will never display the device permission (it returns a Promise&lt;?Transport>, null if it fails to find a device).
 
 #### open
 

--- a/packages/hw-transport-webusb/src/webusb.js
+++ b/packages/hw-transport-webusb/src/webusb.js
@@ -3,11 +3,22 @@ import { ledgerUSBVendorId } from "@ledgerhq/devices";
 
 const ledgerDevices = [{ vendorId: ledgerUSBVendorId }];
 
-export function requestLedgerDevice(): Promise<USBDevice> {
-  return Promise.resolve().then(() =>
-    // $FlowFixMe
-    navigator.usb.requestDevice({ filters: ledgerDevices })
-  );
+export async function requestLedgerDevice(): Promise<USBDevice> {
+  // $FlowFixMe
+  const device = await navigator.usb.requestDevice({ filters: ledgerDevices });
+  return device;
+}
+
+export async function getLedgerDevices(): Promise<USBDevice[]> {
+  // $FlowFixMe
+  const devices = await navigator.usb.getDevices();
+  return devices.filter(d => d.vendorId === ledgerUSBVendorId);
+}
+
+export async function getFirstLedgerDevice(): Promise<USBDevice> {
+  const existingDevices = await getLedgerDevices();
+  if (existingDevices.length > 0) return existingDevices[0];
+  return requestLedgerDevice();
 }
 
 export const isSupported = (): Promise<boolean> =>
@@ -16,11 +27,3 @@ export const isSupported = (): Promise<boolean> =>
       // $FlowFixMe
       typeof navigator.usb === "object"
   );
-
-export const getLedgerDevices = (): Promise<USBDevice[]> =>
-  Promise.resolve()
-    .then(() =>
-      // $FlowFixMe
-      navigator.usb.getDevices()
-    )
-    .then(devices => devices.filter(d => d.vendorId === ledgerUSBVendorId));


### PR DESCRIPTION
- this will improve UX by asking requestDevice() less time: if a device was already accepted, it will be used and won't be reasked to the user.
- properly detect the disconnect event of a device. (you can `transport.on("disconnect", cb)`)
- introduced request() and openConnected() for custom usecases