### PR TITLE
Tighten the check for availability of webusb

### DIFF
--- a/packages/hw-transport-webusb/src/webusb.js
+++ b/packages/hw-transport-webusb/src/webusb.js
@@ -23,7 +23,8 @@ export async function getFirstLedgerDevice(): Promise<USBDevice> {
 
 export const isSupported = (): Promise<boolean> =>
   Promise.resolve(
-    typeof navigator === "object" &&
-      // $FlowFixMe
-      typeof navigator.usb === "object"
+    // $FlowFixMe
+    !!navigator &&
+      !!navigator.usb &&
+        typeof navigator.usb.getDevices === 'function'
   );


### PR DESCRIPTION
Fix for the following scenario;

    // navigator = null
    typeof navigator === "object" &&
      typeof navigator.usb === "object"

Then it throws;

    TypeError: Cannot read property 'usb' of null