### PR TITLE
[transport-hid] Fix device identification not relying on correct info

### DIFF
--- a/packages/devices/src/index.js
+++ b/packages/devices/src/index.js
@@ -59,6 +59,12 @@ const devices = {
   }
 };
 
+const productMap = {
+  Blue: "blue",
+  "Nano S": "nanoS",
+  "Nano X": "nanoX"
+};
+
 // $FlowFixMe
 const devicesList: DeviceModel[] = Object.values(devices);
 
@@ -82,8 +88,16 @@ export const getDeviceModel = (id: DeviceModelId): DeviceModel => {
 export const identifyUSBProductId = (usbProductId: number): ?DeviceModel => {
   const legacy = devicesList.find(d => d.legacyUsbProductId === usbProductId);
   if (legacy) return legacy;
+
   const mm = usbProductId >> 8;
   const deviceModel = devicesList.find(d => d.productIdMM === mm);
+  return deviceModel;
+};
+
+export const identifyProductName = (productName: string): ?DeviceModel => {
+  const productId = productMap[productName];
+  const deviceModel = devicesList.find(d => d.id === productId);
+
   return deviceModel;
 };
 

--- a/packages/hw-transport-node-hid-noevents/src/TransportNodeHid.js
+++ b/packages/hw-transport-node-hid-noevents/src/TransportNodeHid.js
@@ -10,7 +10,7 @@ import type {
 } from "@ledgerhq/hw-transport";
 import { ledgerUSBVendorId } from "@ledgerhq/devices";
 import hidFraming from "@ledgerhq/devices/lib/hid-framing";
-import { identifyUSBProductId } from "@ledgerhq/devices";
+import { identifyUSBProductId, identifyProductName } from "@ledgerhq/devices";
 import type { DeviceModel } from "@ledgerhq/devices";
 import { TransportError, DisconnectedDevice } from "@ledgerhq/errors";
 
@@ -93,9 +93,7 @@ export default class TransportNodeHidNoEvents extends Transport<?string> {
     // $FlowFixMe
     const info = device.getDeviceInfo();
     this.deviceModel =
-      info && info.serialNumber
-        ? identifyUSBProductId(parseInt(info.serialNumber, 16))
-        : null;
+      info && info.product ? identifyProductName(info.product) : null;
   }
 
   setDisconnected = () => {


### PR DESCRIPTION
> Closes #374 

We were incorrectly using the serial number to identify devices in the constructor.

This PR fixes that by relying on the device `product` string instead.