### PR TITLE
LL-1549 Add error for wrong device app for currency

### DIFF
--- a/packages/errors/src/index.js
+++ b/packages/errors/src/index.js
@@ -143,6 +143,9 @@ export const WebsocketConnectionFailed = createCustomErrorClass(
 export const WrongDeviceForAccount = createCustomErrorClass(
   "WrongDeviceForAccount"
 );
+export const WrongAppForCurrency = createCustomErrorClass(
+  "WrongAppForCurrency"
+);
 export const ETHAddressNonEIP = createCustomErrorClass("ETHAddressNonEIP");
 export const CantScanQRCode = createCustomErrorClass("CantScanQRCode");
 export const FeeNotLoaded = createCustomErrorClass("FeeNotLoaded");


### PR DESCRIPTION
Error to be thrown from the new commands on common to check device app and account device