### PR TITLE
Document `createPaymentTransactionNew` "bech32" additionals param

### DIFF
--- a/packages/hw-app-btc/README.md
+++ b/packages/hw-app-btc/README.md
@@ -129,7 +129,9 @@ To sign a transaction involving standard (P2PKH) inputs, call createPaymentTrans
 -   `sigHashType` **[number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** is the hash type of the transaction to sign, or default (all) (optional, default `SIGHASH_ALL`)
 -   `segwit` **[boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** is an optional boolean indicating wether to use segwit or not (optional, default `false`)
 -   `initialTimestamp` **[number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)?** is an optional timestamp of the function call to use for coins that necessitate timestamps only, (not the one that the tx will include)
--   `additionals` **[Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)>** list of additionnal options-   "abc" for bch
+-   `additionals` **[Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)>** list of additionnal options:
+    -   "bech32" for spending native segwit outputs
+    -   "abc" for bch
     -   "gold" for btg
     -   "bipxxx" for using BIPxxx
     -   "sapling" to indicate a zec transaction is supporting sapling (to be set over block 419200) (optional, default `[]`)


### PR DESCRIPTION
To spend native segwit outputs, `bech32` needs to be included in the additionals param. This wasn't documented.