### PR TITLE
LL-1711 Change default timeouts for transports

### DIFF
--- a/packages/hw-transport/src/Transport.js
+++ b/packages/hw-transport/src/Transport.js
@@ -50,7 +50,7 @@ export type Observer<Ev> = $ReadOnly<{
  * it can be for instance an ID, an file path, a URL,...
  */
 export default class Transport<Descriptor> {
-  exchangeTimeout: number = 30000;
+  exchangeTimeout: number = 60000;
 
   /**
    * Statically check if a transport is supported on the user's platform/browser.
@@ -208,7 +208,7 @@ TransportFoo.open(descriptor).then(transport => ...)
 TransportFoo.create().then(transport => ...)
    */
   static create(
-    openTimeout?: number = 3000,
+    openTimeout?: number = 30000,
     listenTimeout?: number
   ): Promise<Transport<Descriptor>> {
     return new Promise((resolve, reject) => {


### PR DESCRIPTION
I can't really test this due to the nested dependencies between live-common, mobile, and the individual transports with hw-transport package itself, Metro bundler goes nuts. But I assume that these are the timeouts we want to modify in order to avoide the scenario where the user selects a nano x and has not enough time to even turn it on before a timeout (3 seconds!).

Also 60 seconds for the other timeout because that's what I wrote on Jira for some reason 🤷‍♂ 

https://github.com/LedgerHQ/ledgerjs/blob/master/packages/hw-transport/src/Transport.js#L211
