### PR TITLE
Add `TransportWebUSBGestureRequired` error

### DIFF
--- a/packages/errors/src/index.js
+++ b/packages/errors/src/index.js
@@ -137,6 +137,9 @@ export const TransportOpenUserCancelled = createCustomErrorClass(
 export const TransportInterfaceNotAvailable = createCustomErrorClass(
   "TransportInterfaceNotAvailable"
 );
+export const TransportWebUSBGestureRequired = createCustomErrorClass(
+  "TransportWebUSBGestureRequired"
+);
 export const DeviceShouldStayInApp = createCustomErrorClass(
   "DeviceShouldStayInApp"
 );

--- a/packages/hw-transport-webusb/src/TransportWebUSB.js
+++ b/packages/hw-transport-webusb/src/TransportWebUSB.js
@@ -12,6 +12,7 @@ import { log } from "@ledgerhq/logs";
 import {
   TransportOpenUserCancelled,
   TransportInterfaceNotAvailable,
+  TransportWebUSBGestureRequired,
   DisconnectedDeviceDuringOperation,
   DisconnectedDevice
 } from "@ledgerhq/errors";
@@ -74,7 +75,15 @@ export default class TransportWebUSB extends Transport<USBDevice> {
         }
       },
       error => {
-        observer.error(new TransportOpenUserCancelled(error.message));
+        if (
+          window.DOMException &&
+          error instanceof window.DOMException &&
+          error.code === 18
+        ) {
+          observer.error(new TransportWebUSBGestureRequired(error.message));
+        } else {
+          observer.error(new TransportOpenUserCancelled(error.message));
+        }
       }
     );
     function unsubscribe() {


### PR DESCRIPTION
Following the discussion initiated [here](https://github.com/LedgerHQ/ledger-vault-front/pull/1032#pullrequestreview-284999228), this PR adds a more precise way to identify the error occuring when WebUSB transport is created outside of the context of a click.