### PR TITLE
Add GasLessThanEstimate error for warning user of low gas

### DIFF
--- a/packages/errors/src/index.js
+++ b/packages/errors/src/index.js
@@ -104,6 +104,7 @@ export const NotEnoughBalanceBecauseDestinationNotCreated = createCustomErrorCla
 );
 export const NoAccessToCamera = createCustomErrorClass("NoAccessToCamera");
 export const NotEnoughGas = createCustomErrorClass("NotEnoughGas");
+export const GasLessThanEstimate = createCustomErrorClass("GasLessThanEstimate");
 export const PasswordsDontMatchError = createCustomErrorClass(
   "PasswordsDontMatch"
 );


### PR DESCRIPTION
This error could be used to warn the user that the input gaslimit is lower than our estimation and that the transaction might fail with outofgas. The below wording is just an example, we could use this warning to show a banner, or a second popu like we do when fees are too high for instance.

<img width="514" alt="image" src="https://user-images.githubusercontent.com/4631227/66122555-4b48ad80-e5e0-11e9-9851-b5fbd77306d3.png">
