### PR TITLE
Add NotEnoughBalanceInParentAccount error

### DIFF
--- a/packages/errors/src/index.js
+++ b/packages/errors/src/index.js
@@ -106,6 +106,9 @@ export const ManagerUninstallBTCDep = createCustomErrorClass(
 export const NetworkDown = createCustomErrorClass("NetworkDown");
 export const NoAddressesFound = createCustomErrorClass("NoAddressesFound");
 export const NotEnoughBalance = createCustomErrorClass("NotEnoughBalance");
+export const NotEnoughBalanceInParentAccount = createCustomErrorClass(
+  "NotEnoughBalanceInParentAccount"
+);
 export const NotEnoughSpendableBalance = createCustomErrorClass(
   "NotEnoughSpendableBalance"
 );


### PR DESCRIPTION
With this new error, we will be able to have better wording for tezos KT accounts with a parent without funds but also (i think) for erc20 tokens with an empty parent. Right now we are throwing the not enough gas or something like that which is not ideal.

I will need this and a bump in order to use it on common, I'll yalc for now