### PR TITLE
LL-2112 USB no longer working on Android 24 devices

### DIFF
--- a/packages/react-native-hid/android/src/main/java/com/ledgerwallet/hid/HIDDevice.java
+++ b/packages/react-native-hid/android/src/main/java/com/ledgerwallet/hid/HIDDevice.java
@@ -74,7 +74,7 @@ public class HIDDevice {
                     while (offset != command.length) {
                         int blockSize = (command.length - offset > HID_BUFFER_SIZE ? HID_BUFFER_SIZE : command.length - offset);
                         System.arraycopy(command, offset, transferBuffer, 0, blockSize);
-                        if (!request.queue(ByteBuffer.wrap(transferBuffer))) {
+                        if (!request.queue(ByteBuffer.wrap(transferBuffer), HID_BUFFER_SIZE)) {
                             request.close();
                             throw new Exception("I/O error");
                         }
@@ -91,7 +91,7 @@ public class HIDDevice {
                     while ((responseData = LedgerHelper.unwrapResponseAPDU(LEDGER_DEFAULT_CHANNEL, response.toByteArray(),
                             HID_BUFFER_SIZE)) == null) {
                         responseBuffer.clear();
-                        if (!request.queue(responseBuffer)) {
+                        if (!request.queue(responseBuffer, HID_BUFFER_SIZE)) {
                             request.close();
                             throw new Exception("I/O error");
                         }


### PR DESCRIPTION
**Desc:**
On older android devices running API level 24 or 25, USB communication was no longer working.

**Type:**
Bug Fix

**Issue:**
LL-2112

