### PR TITLE
emit "responsive" event when device awakes

### DIFF
--- a/packages/hw-transport/src/Transport.js
+++ b/packages/hw-transport/src/Transport.js
@@ -277,11 +277,16 @@ TransportFoo.create().then(transport => ...)
       resolveBusy = r;
     });
     this.exchangeBusyPromise = busyPromise;
+    let unresponsiveReached = false;
     const timeout = setTimeout(() => {
+      unresponsiveReached = true;
       this.emit("unresponsive");
     }, this.unresponsiveTimeout);
     try {
       const res = await f();
+      if (unresponsiveReached) {
+        this.emit("responsive");
+      }
       return res;
     } finally {
       clearTimeout(timeout);


### PR DESCRIPTION
if "unresponsive" event was previously emit, a "responsive" symetric event will be emitted when the device is back and has answered the previously blocking APDU.