### PR TITLE
fix(TransportWebHID): device undefined error handling

### DIFF
--- a/packages/hw-transport-webhid/src/TransportWebHID.js
+++ b/packages/hw-transport-webhid/src/TransportWebHID.js
@@ -114,6 +114,10 @@ export default class TransportWebHID extends Transport<HIDDevice> {
     let unsubscribed = false;
     getFirstLedgerDevice().then(
       (device) => {
+        if (!device) {
+          throw new Error('Access denied to use Ledger device')
+        }
+
         if (!unsubscribed) {
           const deviceModel = identifyUSBProductId(device.productId);
           observer.next({ type: "add", descriptor: device, deviceModel });

--- a/packages/hw-transport-webhid/src/TransportWebHID.js
+++ b/packages/hw-transport-webhid/src/TransportWebHID.js
@@ -115,10 +115,10 @@ export default class TransportWebHID extends Transport<HIDDevice> {
     getFirstLedgerDevice().then(
       (device) => {
         if (!device) {
-          throw new Error('Access denied to use Ledger device')
-        }
-
-        if (!unsubscribed) {
+          observer.error(
+            new TransportOpenUserCancelled("Access denied to use Ledger device")
+          );
+        } else if (!unsubscribed) {
           const deviceModel = identifyUSBProductId(device.productId);
           observer.next({ type: "add", descriptor: device, deviceModel });
           observer.complete();


### PR DESCRIPTION
## Description
This fix handles uncaught exception `TypeError: Cannot read property 'productId' of undefined`. It only happens on Windows Chrome.

## Reproduce
On Windows Chrome,
1. start a new tab and try to access ledge using `hw-transport-webhid` module.
2. HID permission popup shows. Click cancel
3. exception will occur and observer does not pass it.

## The fix
Check for device existence, if it is not defined, call observer.error