### PR TITLE
add @ledgerhq/logs dependency to @ledgerhq/hw-app-btc

### DIFF
--- a/packages/hw-app-btc/package.json
+++ b/packages/hw-app-btc/package.json
@@ -27,6 +27,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@ledgerhq/hw-transport": "^5.15.0",
+    "@ledgerhq/logs": "^5.15.0",
     "bip32-path": "^0.4.2",
     "invariant": "^2.2.4",
     "ripemd160": "2",


### PR DESCRIPTION
The `@ledgerhq/hw-app-btc` package relies on an implicit dependency of `@ledgerhq/logs` which makes it unusable with stricter package managers like pnpm or yarn berry.

```
@ledgerhq/hw-app-btc tried to access @ledgerhq/logs, but it isn't declared in its dependencies; this makes the require call ambiguous and unsound.

Required package: @ledgerhq/logs (via "@ledgerhq/logs")
Required by: @ledgerhq/hw-app-btc@npm:5.16.0 (via /home/runner/work/platform-sdk/platform-sdk/.yarn/cache/@ledgerhq-hw-app-btc-npm-5.16.0-40feab515a-2.zip/node_modules/@ledgerhq/hw-app-btc/lib/)
```

A release with this fix would be appreciated as soon as it's merged so the package can be installed with the aforementioned package managers.