### PR TITLE
BCH: add flag "cashaddr" to use CashAddr format for txs

### DIFF
--- a/packages/hw-app-btc/src/startUntrustedHashTransactionInput.js
+++ b/packages/hw-app-btc/src/startUntrustedHashTransactionInput.js
@@ -13,7 +13,9 @@ export function startUntrustedHashTransactionInputRaw(
   overwinter?: boolean = false,
   additionals: Array<string> = []
 ) {
-  const p2 = bip143
+  const p2 = additionals.includes("cashaddr")
+    ? 0x03
+    : bip143
     ? additionals.includes("sapling")
       ? 0x05
       : overwinter


### PR DESCRIPTION
enables support of device formatting of cashaddr during transactions with the flag "cashaddr".