### PR TITLE
fix(cryptoassets): add countervalueTicker=PDOT for Polkadot

### DIFF
--- a/packages/cryptoassets/src/currencies.js
+++ b/packages/cryptoassets/src/currencies.js
@@ -1767,6 +1767,7 @@ const cryptocurrenciesById: { [name: string]: CryptoCurrency } = {
     name: "Polkadot",
     managerAppName: "Polkadot",
     ticker: "DOT",
+    countervalueTicker: "PDOT",
     scheme: "polkadot",
     color: "#E6007A",
     family: "polkadot",


### PR DESCRIPTION
Counter Value ticker on partner's API is "PDOT" instead of "DOT".

Use custom coutervalueTicker alias for fetching countervalues.

Tested on Ledger Live Desktop WIP - works as intended.

![image](https://user-images.githubusercontent.com/70533374/100647489-e43b9b80-333f-11eb-9911-483e1728a052.png)
