### PR TITLE
Prevent throw if device reset is failing

### DIFF
--- a/packages/hw-transport-webusb/src/TransportWebUSB.js
+++ b/packages/hw-transport-webusb/src/TransportWebUSB.js
@@ -118,7 +118,7 @@ export default class TransportWebUSB extends Transport<USBDevice> {
     if (device.configuration === null) {
       await device.selectConfiguration(configurationValue);
     }
-    await device.reset();
+    await gracefullyResetDevice(device);
     const iface = device.configurations[0].interfaces.find(({ alternates }) =>
       alternates.some((a) => a.interfaceClass === 255)
     );
@@ -160,7 +160,7 @@ export default class TransportWebUSB extends Transport<USBDevice> {
   async close(): Promise<void> {
     await this.exchangeBusyPromise;
     await this.device.releaseInterface(this.interfaceNumber);
-    await this.device.reset();
+    await gracefullyResetDevice(this.device);
     await this.device.close();
   }
 
@@ -202,4 +202,12 @@ export default class TransportWebUSB extends Transport<USBDevice> {
     });
 
   setScrambleKey() {}
+}
+
+async function gracefullyResetDevice(device: USBDevice) {
+  try {
+    await device.reset();
+  } catch (err) {
+    console.warn(err);
+  }
 }


### PR DESCRIPTION
So, this PR mitigates impact of recent regression on Chrome 87 + Windows (reported at least 3 times on Vault side). The actual workaround is to disable "new WebUSB backend" (whatever that means) using chrome flag. With those changes no more need.

Tested on:
- Windows 10 + Chrome 87 (& validated I was falling in the error case + tested basic ADPUs)
- Linux + Chrome 87 (no apparent regression detected, which is not really surprising given the code lol)

What it look like (VM screen resolution FTW)

![YAYA](https://user-images.githubusercontent.com/315259/100774432-5bd1ff00-3402-11eb-9543-b98e29ee5511.png)
