### PR TITLE
Add currency definitions for Stargate and Testnet

### DIFF
--- a/packages/cryptoassets/src/currencies.js
+++ b/packages/cryptoassets/src/currencies.js
@@ -670,6 +670,68 @@ const cryptocurrenciesById: { [name: string]: CryptoCurrency } = {
       },
     ],
   },
+  cosmos_stargate: {
+    type: "CryptoCurrency",
+    id: "cosmos_stargate",
+    coinType: 118,
+    name: "Cosmos",
+    managerAppName: "Cosmos",
+    ticker: "ATOM",
+    scheme: "cosmos_stargate",
+    color: "#16192f",
+    family: "cosmos",
+    // FIXME: enable it back when confirmation number is fixed
+    // blockAvgTime: 8,
+    units: [
+      {
+        name: "Atom",
+        code: "ATOM",
+        magnitude: 6,
+      },
+      {
+        name: "microAtom",
+        code: "uatom",
+        magnitude: 0,
+      },
+    ],
+    explorerViews: [
+      {
+        tx: "https://www.mintscan.io/txs/$hash",
+        address: "https://www.mintscan.io/validators/$address",
+      },
+    ],
+  },
+  cosmos_stargate_testnet: {
+    type: "CryptoCurrency",
+    id: "cosmos_stargate_testnet",
+    coinType: 118,
+    name: "Cosmos (Testnet)",
+    managerAppName: "Cosmos",
+    ticker: "MUON",
+    scheme: "cosmos_stargate_testnet",
+    color: "#16192f",
+    family: "cosmos",
+    // FIXME: enable it back when confirmation number is fixed
+    // blockAvgTime: 8,
+    units: [
+      {
+        name: "Muon",
+        code: "MUON",
+        magnitude: 6,
+      },
+      {
+        name: "microMuon",
+        code: "umuon",
+        magnitude: 0,
+      },
+    ],
+    explorerViews: [
+      {
+        tx: "https://testnet.mintscan.io/txs/$hash",
+        address: "https://testnet.mintscan.io/validators/$address",
+      },
+    ],
+  },
   dash: {
     type: "CryptoCurrency",
     id: "dash",


### PR DESCRIPTION
`cosmos_stargate` should be the identifier and the payment uri scheme for Stargate (which will cosmoshub-4)

`cosmos_stargate_testnet` should be the identifier and the payment uri for the Stargate testnet.