### PR TITLE
Update migrate_webusb.md

### DIFF
--- a/docs/migrate_webusb.md
+++ b/docs/migrate_webusb.md
@@ -1,6 +1,6 @@
 `@ledgerhq/hw-transport-u2f` and `@ledgerhq/hw-transport-webauthn` have been deprecated.
 
-**We strongly advise to migrate to [`@ledgerhq/hw-transport-webusb`](../packages/hw-transport-webusb) or [`@ledgerhq/hw-transport-webhid`](../packages/hw-transport-webusb).**
+**We strongly advise to migrate to [`@ledgerhq/hw-transport-webusb`](../packages/hw-transport-webusb) or [`@ledgerhq/hw-transport-webhid`](../packages/hw-transport-webhid).**
 
 ## Why is it deprecated?
 


### PR DESCRIPTION
Seems the link of `@ledgerhq/hw-transport-webhid` was pointed to `../packages/hw-transport-webusb` in `docs/migrate_webusb.md`.

This PR update the link to `../packages/hw-transport-webhid`.