### PR TITLE
Fix chunksize bug in case of long VRS value

### DIFF
--- a/packages/hw-app-eth/src/Eth.js
+++ b/packages/hw-app-eth/src/Eth.js
@@ -206,6 +206,19 @@ export default class Eth {
       );
 
       rlpOffset = rawTx.length - (rlpVrs.length - 1);
+
+      // First byte >= 0xf7 means the length of the list length doesn't fit in a single byte.
+      if (rlpVrs[0] >= 0xf7) {
+        // Increment rlpOffset to account for that extra byte.
+        rlpOffset++;
+
+        // Compute size of the list length.
+        let sizeOfListLen = rlpVrs[0] - 0xf7;
+
+        // Increase rlpOffset by the size of the list length.
+        rlpOffset += sizeOfListLen - 1;
+      }
+
       const chainIdSrc = rlpTx[6];
       const chainIdBuf = Buffer.alloc(4);
       chainIdSrc.copy(chainIdBuf, 4 - chainIdSrc.length);
@@ -240,6 +253,7 @@ export default class Eth {
       }
       toSend.push(buffer);
       offset += chunkSize;
+      console.log(buffer.toString("hex"));
     }
 
     rlpTx = ethers.utils.RLP.decode("0x" + rawTxHex);

--- a/packages/hw-app-eth/src/Eth.js
+++ b/packages/hw-app-eth/src/Eth.js
@@ -253,7 +253,6 @@ export default class Eth {
       }
       toSend.push(buffer);
       offset += chunkSize;
-      console.log(buffer.toString("hex"));
     }
 
     rlpTx = ethers.utils.RLP.decode("0x" + rawTxHex);

--- a/packages/hw-app-eth/src/Eth.js
+++ b/packages/hw-app-eth/src/Eth.js
@@ -207,8 +207,8 @@ export default class Eth {
 
       rlpOffset = rawTx.length - (rlpVrs.length - 1);
 
-      // First byte >= 0xf7 means the length of the list length doesn't fit in a single byte.
-      if (rlpVrs[0] >= 0xf7) {
+      // First byte > 0xf7 means the length of the list length doesn't fit in a single byte.
+      if (rlpVrs[0] > 0xf7) {
         // Increment rlpOffset to account for that extra byte.
         rlpOffset++;
 

--- a/packages/hw-app-eth/tests/Eth.test.js
+++ b/packages/hw-app-eth/tests/Eth.test.js
@@ -193,6 +193,35 @@ test("signTransactionChunkedLimit", async () => {
   });
 });
 
+test("signTransactionChunkedLimitBigVRS", async () => {
+  const Transport = createTransportReplayer(
+    RecordStore.fromString(`
+    => e004000096058000002c8000003c800000000000000000000000f9015782abcd8609184e72a00082271094aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa820300b8edbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+    <= 9000
+    => e004800095bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+    <= 9000
+    => e004800044bb25a090ee578f5ed7c417fae04264416a43d72e70859d8978ca58455a30b67bbeda8aa0284afa8b169a8bfb677238b69b16387f262c9173ad6f40677d1dee630fed8455
+    <= 9000
+    `)
+  );
+  const transport = await Transport.open();
+  const eth = new Eth(transport);
+  const result = await eth.signTransaction(
+    "44'/60'/0'/0/0",
+    "f9015782abcd8609184e72a00082271094aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa820300b8edbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb25a090ee578f5ed7c417fae04264416a43d72e70859d8978ca58455a30b67bbeda8aa0284afa8b169a8bfb677238b69b16387f262c9173ad6f40677d1dee630fed8455",
+  );
+  expect(result).toEqual({
+    r: "00",
+    s: "", //ed8455
+    v: "90",
+    /*
+    r: "25a090ee578f5ed7c417fae04264416a43d72e70859d8978ca58455a30b67bbe",
+    s: "da8aa0284afa8b169a8bfb677238b69b16387f262c9173ad6f40677d1dee630f", //ed8455
+    v: "1b",*/
+  });
+});
+
+
 test("signPersonalMessage", async () => {
   const Transport = createTransportReplayer(
     RecordStore.fromString(`

--- a/packages/hw-app-eth/tests/Eth.test.js
+++ b/packages/hw-app-eth/tests/Eth.test.js
@@ -178,7 +178,7 @@ test("signTransactionChunkedLimit", async () => {
     <= 9000
     => e00480000400018080
     <= 1bdc6ad1d9d847defdffde2f3b70004c89a1a8a6c614fec484891ae8f1ebc46f9966159ca542f5cf36d64278218bfcce24ba96d7495dec25b10a7609346ca063ec9000
-    `)
+    `) // Incorrect signature but it doesn't matter for tests
   );
   const transport = await Transport.open();
   const eth = new Eth(transport);
@@ -201,7 +201,7 @@ test("signTransactionChunkedLimitBigVRS", async () => {
     => e004800095bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
     <= 9000
     => e004800044bb25a090ee578f5ed7c417fae04264416a43d72e70859d8978ca58455a30b67bbeda8aa0284afa8b169a8bfb677238b69b16387f262c9173ad6f40677d1dee630fed8455
-    <= 9000
+    <= 1bdc6ad1d9d847defdffde2f3b70004c89a1a8a6c614fec484891ae8f1ebc46f9966159ca542f5cf36d64278218bfcce24ba96d7495dec25b10a7609346ca063ec9000
     `)
   );
   const transport = await Transport.open();
@@ -211,13 +211,9 @@ test("signTransactionChunkedLimitBigVRS", async () => {
     "f9015782abcd8609184e72a00082271094aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa820300b8edbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb25a090ee578f5ed7c417fae04264416a43d72e70859d8978ca58455a30b67bbeda8aa0284afa8b169a8bfb677238b69b16387f262c9173ad6f40677d1dee630fed8455",
   );
   expect(result).toEqual({
-    r: "00",
-    s: "", //ed8455
-    v: "90",
-    /*
-    r: "25a090ee578f5ed7c417fae04264416a43d72e70859d8978ca58455a30b67bbe",
-    s: "da8aa0284afa8b169a8bfb677238b69b16387f262c9173ad6f40677d1dee630f", //ed8455
-    v: "1b",*/
+    r: "dc6ad1d9d847defdffde2f3b70004c89a1a8a6c614fec484891ae8f1ebc46f99",
+    s: "66159ca542f5cf36d64278218bfcce24ba96d7495dec25b10a7609346ca063ec",
+    v: "1b",
   });
 });
 


### PR DESCRIPTION
`ledgerjs` is expected to reduce `chunkSize` by one if the VRS value begins at the start of a new APDU.

This was done in most case, but in the case of a big VRS value, then the `chunkSize` was not properly updated.

This PR fixes this issue.

This issue was first reported on [app-ethereum](https://github.com/LedgerHQ/app-ethereum/issues/147) repo.

Edit: linked the wrong issue on app-ethereum.