### PR TITLE
LL-4600 Map HID errors to DisconnectedDeviceDuringOperation

### DIFF
--- a/packages/hw-transport-node-hid-noevents/src/TransportNodeHid.ts
+++ b/packages/hw-transport-node-hid-noevents/src/TransportNodeHid.ts
@@ -134,7 +134,6 @@ export default class TransportNodeHidNoEvents extends Transport {
               : e;
           if (maybeMappedError instanceof DisconnectedDeviceDuringOperation) {
             this.setDisconnected();
-            return reject(new DisconnectedDevice(e.message));
           }
 
           reject(maybeMappedError);

--- a/packages/hw-transport-node-hid-noevents/src/TransportNodeHid.ts
+++ b/packages/hw-transport-node-hid-noevents/src/TransportNodeHid.ts
@@ -112,7 +112,7 @@ export default class TransportNodeHidNoEvents extends Transport {
       return Promise.resolve();
     } catch (e) {
       const maybeMappedError =
-        e && e.message ? DisconnectedDeviceDuringOperation(e.message) : e;
+        e && e.message ? new DisconnectedDeviceDuringOperation(e.message) : e;
       if (maybeMappedError instanceof DisconnectedDeviceDuringOperation) {
         this.setDisconnected();
       }
@@ -129,7 +129,9 @@ export default class TransportNodeHidNoEvents extends Transport {
 
         if (e) {
           const maybeMappedError =
-            e && e.message ? DisconnectedDeviceDuringOperation(e.message) : e;
+            e && e.message
+              ? new DisconnectedDeviceDuringOperation(e.message)
+              : e;
           if (maybeMappedError instanceof DisconnectedDeviceDuringOperation) {
             this.setDisconnected();
             return reject(new DisconnectedDevice(e.message));

--- a/packages/hw-transport-node-hid-noevents/src/TransportNodeHid.ts
+++ b/packages/hw-transport-node-hid-noevents/src/TransportNodeHid.ts
@@ -137,7 +137,7 @@ export default class TransportNodeHidNoEvents extends Transport {
             return reject(new DisconnectedDevice(e.message));
           }
 
-          return Promise.reject(maybeMappedError);
+          reject(maybeMappedError);
         } else {
           const buffer = Buffer.from(res);
           resolve(buffer);

--- a/packages/hw-transport-node-hid-noevents/src/TransportNodeHid.ts
+++ b/packages/hw-transport-node-hid-noevents/src/TransportNodeHid.ts
@@ -36,7 +36,7 @@ export function getDevices(): (Device & { deviceName?: string })[] {
 // Mapping errors from https://github.com/node-hid/node-hid/blob/master/src/HID.cc
 const mapError = (e) => {
   if (e && e.message) {
-    return new DisconnectedDeviceDuringOperation(e);
+    return new DisconnectedDeviceDuringOperation(e.message);
   }
   return e;
 };


### PR DESCRIPTION
Following the discussion over at https://ledgerhq.atlassian.net/browse/LL-4600, we want to introduce better wording for the case where `node-hid` cannot write to the device. Currently, since it's not being mapped, we are getting the error directly from https://github.com/node-hid/node-hid/blob/master/src/HID.cc#L413 and we need to throw our own custom error to introduce translations and specific wording.

I dropped the `isDisconnectedError` in favor of a remap but perhaps there's something else to be done here, I don't like relying on the error messages themselves but I see no other alternative when I look at the source for node-hid. This would still need specific wording on LLD to take advantage of the remap, as far as mobile goes I'm not sure it applies, but I could be wrong.