### PR TITLE
Expose a way to get Model from targetId

### DIFF
--- a/packages/devices/README.md
+++ b/packages/devices/README.md
@@ -16,11 +16,13 @@ Logic for all Ledger devices.
 -   [ledgerUSBVendorId](#ledgerusbvendorid)
 -   [getDeviceModel](#getdevicemodel)
     -   [Parameters](#parameters-1)
--   [identifyUSBProductId](#identifyusbproductid)
+-   [identifyTargetId](#identifytargetid)
     -   [Parameters](#parameters-2)
+-   [identifyUSBProductId](#identifyusbproductid)
+    -   [Parameters](#parameters-3)
 -   [getBluetoothServiceUuids](#getbluetoothserviceuuids)
 -   [getInfosForServiceUuid](#getinfosforserviceuuid)
-    -   [Parameters](#parameters-3)
+    -   [Parameters](#parameters-4)
 -   [DeviceModelId](#devicemodelid)
 -   [DeviceModel](#devicemodel)
     -   [Properties](#properties)
@@ -64,6 +66,17 @@ Type: [number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Globa
 
 Returns **[DeviceModel](#devicemodel)** 
 
+### identifyTargetId
+
+Given a `targetId`, return the deviceModel associated to it,
+based on the first two bytes.
+
+#### Parameters
+
+-   `targetId` **[number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** 
+
+Returns **[DeviceModel](#devicemodel)?** 
+
 ### identifyUSBProductId
 
 #### Parameters
@@ -96,6 +109,7 @@ Type: $Keys&lt;any>
 -   `legacyUsbProductId` **[number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** 
 -   `usbOnly` **[boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** 
 -   `memorySize` **[number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** 
+-   `masks` **[Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)>** 
 -   `getBlockSize` **function (firmwareVersion: [string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)): [number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** 
 -   `bluetoothSpec` **[Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;{serviceUuid: [string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String), writeUuid: [string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String), notifyUuid: [string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)}>?** 
 

--- a/packages/devices/tests/identifyTargetId.test.js
+++ b/packages/devices/tests/identifyTargetId.test.js
@@ -1,0 +1,23 @@
+// @flow
+import { identifyTargetId } from "../src/";
+
+test("check that known targetIds match known devices", () => {
+  const knownTargetIds = {
+    nanoS: [823132162, 823132163, 823132164],
+    nanoX: [855638020],
+    blue: [822149124],
+  };
+
+  for (const modelId in knownTargetIds) {
+    const ids = knownTargetIds[modelId];
+    ids.forEach((id) => {
+      const deviceModel = identifyTargetId(id);
+      expect(deviceModel?.id).toBe(modelId);
+    });
+  }
+});
+
+test("check that unknown targetId is undefined", () => {
+  const shouldBeUndefiend = identifyTargetId(0x123456789);
+  expect(shouldBeUndefiend?.id).toBeFalsy();
+});


### PR DESCRIPTION
This all comes from the context of wanting to expose the model id in a nice way for the proxy transport instead of relying on a fallback to nanoS like we do for `listApps` https://github.com/LedgerHQ/ledger-live-common/blob/master/src/apps/hw.js#L124 we could use the `deviceInfo` we already have access to and enhance it with the device model data. Or even modify the signature of `DeviceInfo` to include the model data at some point.

This allows us to unlock LNX proxied LLM development, especially in tasks involving the manager where this nanoS fallback brings storage problems.