### PR TITLE
Add axios to hw-app-eth dependencies

### DIFF
--- a/packages/hw-app-eth/package.json
+++ b/packages/hw-app-eth/package.json
@@ -31,6 +31,7 @@
     "@ledgerhq/errors": "^6.2.0",
     "@ledgerhq/hw-transport": "^6.2.0",
     "@ledgerhq/logs": "^6.2.0",
+    "axios": "^0.21.1",
     "bignumber.js": "^9.0.1",
     "ethers": "^5.4.2"
   },


### PR DESCRIPTION
This PR adds `axios` to `hw-app-eth` dependencies. It was added in the last release and is used here: https://github.com/LedgerHQ/ledgerjs/blob/master/packages/hw-app-eth/src/contracts.ts#L1