### PR TITLE
Workaround fix for null chainID if EIP 155 marker intersects packet boundary

### DIFF
--- a/packages/hw-app-eth/src/Eth.ts
+++ b/packages/hw-app-eth/src/Eth.ts
@@ -239,9 +239,9 @@ export default class Eth {
           ? rawTx.length - offset
           : maxChunkSize;
 
-      if (rlpOffset != 0 && offset + chunkSize == rlpOffset) {
+      if (rlpOffset != 0 && offset + chunkSize >= rlpOffset) {
         // Make sure that the chunk doesn't end right on the EIP 155 marker if set
-        chunkSize--;
+        chunkSize = rawTx.length - offset;
       }
 
       const buffer = Buffer.alloc(


### PR DESCRIPTION
The Ledger Eth app appears to exhibit a bug whereby if the EIP 155 marker (containing the chainID and null r,s values) is split at the APDU boundary, then the app fails to parse the chainID correctly and sets it to 0. This is most easily observed when the chainID is 4 bytes (as with Harmony ONE).

This workaround avoids the split by enlarging the chunk to incorporate the rest of the data if a split would happen. Since the EIP 155 marker is only expected to be 7 bytes or less, this does not increase the chunk size far beyond the 150 byte soft maximum.