### PR TITLE
Add callbacks

### DIFF
--- a/packages/hw-app-btc/README.md
+++ b/packages/hw-app-btc/README.md
@@ -70,25 +70,26 @@ Ledger Hardware Wallet BTC JavaScript bindings. Also supports many altcoins.
 *   [AppClient](#appclient)
     *   [Parameters](#parameters-19)
 *   [ClientCommandInterpreter](#clientcommandinterpreter)
-*   [MerkelizedPsbt](#merkelizedpsbt)
     *   [Parameters](#parameters-20)
-*   [Merkle](#merkle)
+*   [MerkelizedPsbt](#merkelizedpsbt)
     *   [Parameters](#parameters-21)
-*   [MerkleMap](#merklemap)
+*   [Merkle](#merkle)
     *   [Parameters](#parameters-22)
-*   [WalletPolicy](#walletpolicy)
+*   [MerkleMap](#merklemap)
     *   [Parameters](#parameters-23)
-*   [extract](#extract)
+*   [WalletPolicy](#walletpolicy)
     *   [Parameters](#parameters-24)
-*   [finalize](#finalize)
+*   [extract](#extract)
     *   [Parameters](#parameters-25)
-*   [clearFinalizedInput](#clearfinalizedinput)
+*   [finalize](#finalize)
     *   [Parameters](#parameters-26)
-*   [writePush](#writepush)
+*   [clearFinalizedInput](#clearfinalizedinput)
     *   [Parameters](#parameters-27)
+*   [writePush](#writepush)
+    *   [Parameters](#parameters-28)
 *   [PsbtV2](#psbtv2)
 *   [serializeTransactionOutputs](#serializetransactionoutputs-1)
-    *   [Parameters](#parameters-28)
+    *   [Parameters](#parameters-29)
     *   [Examples](#examples-12)
 *   [SignP2SHTransactionArg](#signp2shtransactionarg)
     *   [Properties](#properties-1)
@@ -590,6 +591,10 @@ executed, ie SignPsbt, getWalletAddress, etc.
 If the command yelds results to the client, as signPsbt does, the yielded
 data will be accessible after the command completed by calling getYielded(),
 which will return the yields in the same order as they came in.
+
+#### Parameters
+
+*   `progressCallback` **function (): void** 
 
 ### MerkelizedPsbt
 

--- a/packages/hw-app-btc/src/newops/appClient.ts
+++ b/packages/hw-app-btc/src/newops/appClient.ts
@@ -96,7 +96,7 @@ export class AppClient {
       throw new Error("Invalid HMAC length");
     }
 
-    const clientInterpreter = new ClientCommandInterpreter();
+    const clientInterpreter = new ClientCommandInterpreter(() => {});
     clientInterpreter.addKnownList(
       walletPolicy.keys.map((k) => Buffer.from(k, "ascii"))
     );
@@ -123,7 +123,8 @@ export class AppClient {
   async signPsbt(
     psbt: PsbtV2,
     walletPolicy: WalletPolicy,
-    walletHMAC: Buffer | null
+    walletHMAC: Buffer | null,
+    progressCallback: () => void
   ): Promise<Map<number, Buffer>> {
     const merkelizedPsbt = new MerkelizedPsbt(psbt);
 
@@ -131,7 +132,7 @@ export class AppClient {
       throw new Error("Invalid HMAC length");
     }
 
-    const clientInterpreter = new ClientCommandInterpreter();
+    const clientInterpreter = new ClientCommandInterpreter(progressCallback);
 
     // prepare ClientCommandInterpreter
     clientInterpreter.addKnownList(

--- a/packages/hw-app-btc/src/newops/clientCommands.ts
+++ b/packages/hw-app-btc/src/newops/clientCommands.ts
@@ -21,13 +21,14 @@ export class YieldCommand extends ClientCommand {
 
   code = ClientCommandCode.YIELD;
 
-  constructor(results: Buffer[]) {
+  constructor(results: Buffer[], private progressCallback: () => void) {
     super();
     this.results = results;
   }
 
   execute(request: Buffer): Buffer {
     this.results.push(Buffer.from(request.subarray(1)));
+    this.progressCallback();
     return Buffer.from("");
   }
 }
@@ -272,9 +273,9 @@ export class ClientCommandInterpreter {
 
   private commands: Map<ClientCommandCode, ClientCommand> = new Map();
 
-  constructor() {
+  constructor(progressCallback: () => void) {
     const commands = [
-      new YieldCommand(this.yielded),
+      new YieldCommand(this.yielded, progressCallback),
       new GetPreimageCommand(this.preimages, this.queue),
       new GetMerkleLeafIndexCommand(this.roots),
       new GetMerkleLeafProofCommand(this.roots, this.queue),

--- a/packages/hw-app-btc/tests/newops/integrationtools.ts
+++ b/packages/hw-app-btc/tests/newops/integrationtools.ts
@@ -52,7 +52,10 @@ export async function runSignTransaction(
     outputWriter.writeVarSlice(Buffer.from(output.scriptPubKey.hex, "hex"));    
   });
   const outputScriptHex = outputWriter.buffer().toString("hex");  
-
+  let callbacks = "";
+  function logCallback(message: string) {
+    callbacks += new Date().toISOString() + " " + message + "\n";
+  }
   const arg: CreateTransactionArg = {    
     inputs,
     additionals,
@@ -60,11 +63,19 @@ export async function runSignTransaction(
     changePath: testPaths.out,
     outputScriptHex,
     lockTime: testTx.locktime,
-    segwit: accountType != AccountType.p2pkh,    
+    segwit: accountType != AccountType.p2pkh,
+    onDeviceSignatureGranted: () => logCallback("CALLBACK: signature granted"),
+    onDeviceSignatureRequested: () => logCallback("CALLBACK: signature requested"),
+    onDeviceStreaming: (arg) => logCallback("CALLBACK: " + JSON.stringify(arg))
   };
+  logCallback("Start createPaymentTransactionNew");
   const tx = await btcNew.createPaymentTransactionNew(arg);
+  logCallback("Done createPaymentTransactionNew");
+  // console.log(callbacks);
   return tx;
 };
+
+
 
 export function addressFormatFromDescriptorTemplate(descTemp: DefaultDescriptorTemplate): AddressFormat {
   if (descTemp == "tr(@0)") return "bech32m";


### PR DESCRIPTION
Fixes https://ledgerhq.atlassian.net/browse/LL-7851

This makes proper use of onDevice* callback functions in CreateTransactionArg. It tries to mimic the behavior of BtcOld, but it can't be done exactly simlar, but during integration testing with speculos it looks pretty good:

```
    2021-10-21T18:33:31.457Z Start createPaymentTransactionNew
    2021-10-21T18:33:31.524Z CALLBACK: {"progress":0.25,"total":4,"index":0}
    2021-10-21T18:33:31.726Z CALLBACK: {"progress":0.5,"total":4,"index":1}
    2021-10-21T18:33:32.014Z CALLBACK: signature requested
    2021-10-21T18:33:50.104Z CALLBACK: signature granted
    2021-10-21T18:33:50.105Z CALLBACK: {"progress":0.75,"total":4,"index":2}
    2021-10-21T18:33:50.280Z CALLBACK: {"progress":1,"total":4,"index":3}
    2021-10-21T18:33:50.282Z Done createPaymentTransactionNew
```