### PR TITLE
Fix sequence=0 becomes 0xffffffff when signing

### DIFF
--- a/packages/hw-app-btc/src/BtcNew.ts
+++ b/packages/hw-app-btc/src/BtcNew.ts
@@ -206,7 +206,7 @@ export default class BtcNew {
 
     const accountType = accountTypeFromArg(arg, psbt, masterFp);
 
-    if (arg.lockTime) {
+    if (arg.lockTime != undefined) {
       // The signer will assume locktime 0 if unset
       psbt.setGlobalFallbackLocktime(arg.lockTime);
     }
@@ -362,10 +362,10 @@ export default class BtcNew {
     // ourselves. But if set, it should be used.
     const redeemScript = input[2] ? Buffer.from(input[2], "hex") : undefined;
     const sequence = input[3];
-    if (sequence) {
+    if (sequence != undefined) {
       psbt.setInputSequence(i, sequence);
     }
-    if (sigHashType) {
+    if (sigHashType != undefined) {
       psbt.setInputSighashType(i, sigHashType);
     }
     const inputTxBuffer = serializeTransaction(inputTx, true);

--- a/packages/hw-app-btc/tests/newops/BtcNew.test.ts
+++ b/packages/hw-app-btc/tests/newops/BtcNew.test.ts
@@ -9,6 +9,7 @@ import {
   WalletPolicy
 } from "../../src/newops/policy";
 import { PsbtV2 } from "../../src/newops/psbtv2";
+import { splitTransaction } from "../../src/splitTransaction";
 import { StandardPurpose, addressFormatFromDescriptorTemplate, creatDummyXpub, masterFingerprint, runSignTransaction, TestingClient } from "./integrationtools";
 import { CoreInput, CoreTx, p2pkh, p2tr, p2wpkh, wrappedP2wpkh, wrappedP2wpkhTwoInputs } from "./testtx";
 
@@ -81,6 +82,18 @@ test("Sign p2tr with sigHashType", async () => {
   })
   const tx = await runSignTransactionNoVerification(testTx, StandardPurpose.p2tr);
   // The verification of the sighashtype is done in MockClient.signPsbt
+})
+
+test("Sign p2tr sequence 0", async() => {
+  const testTx = JSON.parse(JSON.stringify(p2tr));
+  testTx.vin.forEach((input: CoreInput, index: number) => {
+    input.sequence = 0;
+  })
+  const tx = await runSignTransactionNoVerification(testTx, StandardPurpose.p2tr);
+  const txObj = splitTransaction(tx, true);
+  txObj.inputs.forEach((input, index) => {
+    expect(input.sequence.toString("hex")).toEqual("00000000");
+  })
 })
 
 async function runSignTransactionTest(testTx: CoreTx, accountType: StandardPurpose, changePubkey?: string) {


### PR DESCRIPTION
Also fixed two other non-broken but ugly instances of "if (number | undefined)"