### PR TITLE
Add Garlicoin Currency

### DIFF
--- a/packages/cryptoassets/src/abandonseed.ts
+++ b/packages/cryptoassets/src/abandonseed.ts
@@ -19,6 +19,7 @@ const abandonSeedAddresses: Record<string, string> = {
   digibyte: "DG1KhhBKpsyWXTakHNezaDQ34focsXjN1i",
   dogecoin: "DBus3bamQjgJULBJtYXpEzDWQRwF5iwxgC",
   game_credits: "GJgbzWpGhrZmSvc2V5Npqf57Kg9xfB79tj",
+  garlicoin: "M9uvAM1jYk1H5ypaE6pzgLTJpRWu1txi3S",
   komodo: "RW8gfgpCUdgZbkPAs1uJQF2S9681JVkGRi",
   litecoin: "LUWPbpM43E2p7ZSh8cyTBEkvpHmr3cB8Ez",
   nix: "GRpn2DPiQxAczMrQFt2sK1CS8EYdnvSHxo",

--- a/packages/cryptoassets/src/currencies.ts
+++ b/packages/cryptoassets/src/currencies.ts
@@ -1113,6 +1113,41 @@ const cryptocurrenciesById: Record<string, CryptoCurrency> = {
     },
     explorerViews: [],
   },
+  garlicoin: {
+    type: "CryptoCurrency",
+    id: "garlicoin",
+    coinType: 69420,
+    name: "Garlicoin",
+    managerAppName: "Garlicoin",
+    ticker: "GRLC",
+    scheme: "garlicoin",
+    color: "#f2c94c",
+    family: "bitcoin",
+    blockAvgTime: 40,
+    bitcoinLikeInfo: {
+      P2PKH: 38,
+      P2SH: 50,
+      XPUBVersion: 0x0488b21e,
+    },
+    units: [
+      {
+        name: "GRLC",
+        code: "GRLC",
+        magnitude: 8,
+      },
+      {
+        name: "mGRLC",
+        code: "mGRLC",
+        magnitude: 5,
+      },
+    ],
+    explorerViews: [
+      {
+        tx: "https://garli.co.in/tx/$hash",
+        address: "https://garli.co.in/address/$address",
+      },
+    ],
+  },
   gochain: {
     type: "CryptoCurrency",
     id: "gochain",

--- a/packages/cryptoassets/src/currencies.ts
+++ b/packages/cryptoassets/src/currencies.ts
@@ -1122,6 +1122,8 @@ const cryptocurrenciesById: Record<string, CryptoCurrency> = {
     ticker: "GRLC",
     scheme: "garlicoin",
     color: "#f2c94c",
+    supportsSegwit: true,
+    supportsNativeSegwit: true,
     family: "bitcoin",
     blockAvgTime: 40,
     bitcoinLikeInfo: {


### PR DESCRIPTION
[Garlicoin](https://garlicoin.io) has been around since early 2018 is approaching full token distribution. Initially as a fork of Litecoin, an app target can be derived from the existing bitcoin app, see [this PR](https://github.com/LedgerHQ/app-bitcoin-new/pull/6).