### PR TITLE
hw-app-eth nft logic to ignore old app version

### DIFF
--- a/packages/hw-app-eth/src/Eth.ts
+++ b/packages/hw-app-eth/src/Eth.ts
@@ -1307,6 +1307,10 @@ function provideNFTInformation(
   return transport.send(0xe0, 0x14, 0x00, 0x00, data).then(
     () => true,
     (e) => {
+      if (e && e.statusCode === 0x6d00) {
+        // ignore older version of ETH app
+        return false;
+      }
       throw e;
     }
   );


### PR DESCRIPTION
an old app would return 6d00 as the call to provide nft is not supported