### PR TITLE
add helium asset info to cryptoassets

### DIFF
--- a/packages/cryptoassets/src/currencies.ts
+++ b/packages/cryptoassets/src/currencies.ts
@@ -1209,6 +1209,35 @@ const cryptocurrenciesById: Record<string, CryptoCurrency> = {
     ],
     explorerViews: [],
   },
+  helium: {
+    type: "CryptoCurrency",
+    id: "helium",
+    coinType: 904,
+    name: "Helium",
+    managerAppName: "Helium",
+    ticker: "HNT",
+    scheme: "helium",
+    color: "#474DFF",
+    family: "helium",
+    units: [
+      {
+        name: "HNT",
+        code: "HNT",
+        magnitude: 8,
+      },
+      {
+        name: "bones",
+        code: "bones",
+        magnitude: 0,
+      },
+    ],
+    explorerViews: [
+      {
+        tx: "https://explorer.helium.com/txns/$hash",
+        address: "https://explorer.helium.com/accounts/$address",
+      },
+    ],
+  },
   hpb: {
     type: "CryptoCurrency",
     id: "hpb",


### PR DESCRIPTION
adds asset info for Helium (HNT) to the `@ledgerhq/cryptoassets` package