### PR TITLE
refactor: use `buffer/` package to be compatible with browsers

### DIFF
--- a/packages/devices/package.json
+++ b/packages/devices/package.json
@@ -26,6 +26,7 @@
   "dependencies": {
     "@ledgerhq/errors": "^6.10.0",
     "@ledgerhq/logs": "^6.10.0",
+    "buffer": "^6.0.3",
     "rxjs": "6",
     "semver": "^7.3.5"
   },

--- a/packages/devices/src/ble/receiveAPDU.ts
+++ b/packages/devices/src/ble/receiveAPDU.ts
@@ -1,3 +1,4 @@
+import { Buffer } from "buffer/";
 import { TransportError, DisconnectedDevice } from "@ledgerhq/errors";
 import { Observable } from "rxjs";
 import { log } from "@ledgerhq/logs";

--- a/packages/devices/src/ble/sendAPDU.ts
+++ b/packages/devices/src/ble/sendAPDU.ts
@@ -1,3 +1,4 @@
+import { Buffer } from "buffer/";
 import { Observable } from "rxjs";
 import { log } from "@ledgerhq/logs";
 const TagId = 0x05;

--- a/packages/devices/src/hid-framing.ts
+++ b/packages/devices/src/hid-framing.ts
@@ -1,3 +1,4 @@
+import { Buffer } from "buffer/";
 import { TransportError } from "@ledgerhq/errors";
 export type ResponseAcc =
   | {

--- a/packages/devices/src/scrambling.ts
+++ b/packages/devices/src/scrambling.ts
@@ -1,3 +1,4 @@
+import { Buffer } from "buffer/";
 export function wrapApdu(apdu: Buffer, key: Buffer) {
   if (apdu.length === 0) return apdu;
   const result = Buffer.alloc(apdu.length);

--- a/packages/hw-app-algorand/package.json
+++ b/packages/hw-app-algorand/package.json
@@ -30,6 +30,7 @@
     "@ledgerhq/errors": "^6.10.0",
     "@ledgerhq/hw-transport": "^6.11.2",
     "bip32-path": "^0.4.2",
+    "buffer": "^6.0.3",
     "hi-base32": "^0.5.1",
     "js-sha512": "^0.8.0",
     "tweetnacl": "^1.0.3"

--- a/packages/hw-app-algorand/src/Algorand.ts
+++ b/packages/hw-app-algorand/src/Algorand.ts
@@ -14,6 +14,7 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  ********************************************************************************/
+import { Buffer } from "buffer/";
 import type Transport from "@ledgerhq/hw-transport";
 import BIPPath from "bip32-path";
 import { UserRefusedOnDevice } from "@ledgerhq/errors";

--- a/packages/hw-app-btc/package.json
+++ b/packages/hw-app-btc/package.json
@@ -32,6 +32,7 @@
     "bip32-path": "^0.4.2",
     "bitcoinjs-lib": "^5.2.0",
     "bs58": "^4.0.1",
+    "buffer": "^6.0.3",
     "invariant": "^2.2.4",
     "ripemd160": "2",
     "semver": "^7.3.5",

--- a/packages/hw-app-btc/src/Btc.ts
+++ b/packages/hw-app-btc/src/Btc.ts
@@ -1,3 +1,4 @@
+import { Buffer } from "buffer/";
 import type Transport from "@ledgerhq/hw-transport";
 import { pathStringToArray } from "./bip32";
 import BtcNew, { canSupportApp } from "./BtcNew";
@@ -129,11 +130,11 @@ export default class Btc {
         !isPathNormal(path)
       ) {
         console.warn(`WARNING: Using deprecated device protocol to get the public key because
-        
+
         * a non-standard path is requested, and
         * verify flag is false
-        
-        The new protocol only allows export of non-standard paths if the 
+
+        The new protocol only allows export of non-standard paths if the
         verify flag is true. Standard paths are (currently):
 
         M/44'/(1|0)'/X'
@@ -142,9 +143,9 @@ export default class Btc {
         M/86'/(1|0)'/X'
         M/48'/(1|0)'/X'/Y'
 
-        followed by "", "(0|1)", or "(0|1)/b", where a and b are 
+        followed by "", "(0|1)", or "(0|1)/b", where a and b are
         non-hardened. For example, the following paths are standard
-        
+
         M/48'/1'/99'/7'
         M/86'/1'/99'/0
         M/48'/0'/99'/7'/1/17

--- a/packages/hw-app-btc/src/BtcNew.ts
+++ b/packages/hw-app-btc/src/BtcNew.ts
@@ -1,3 +1,4 @@
+import { Buffer } from "buffer/";
 import { crypto } from "bitcoinjs-lib";
 import semver from "semver";
 import { pointCompress } from "tiny-secp256k1";

--- a/packages/hw-app-btc/src/BtcOld.ts
+++ b/packages/hw-app-btc/src/BtcOld.ts
@@ -1,3 +1,4 @@
+import { Buffer } from "buffer/";
 import bs58 from "bs58";
 import RIPEMD160 from "ripemd160";
 import sha from "sha.js";

--- a/packages/hw-app-btc/src/bip32.ts
+++ b/packages/hw-app-btc/src/bip32.ts
@@ -1,3 +1,4 @@
+import { Buffer } from "buffer/";
 import bippath from "bip32-path";
 import bs58check from "bs58check";
 

--- a/packages/hw-app-btc/src/buffertools.ts
+++ b/packages/hw-app-btc/src/buffertools.ts
@@ -1,3 +1,4 @@
+import { Buffer } from "buffer/";
 import varuint from "varuint-bitcoin";
 
 export function unsafeTo64bitLE(n: number): Buffer {

--- a/packages/hw-app-btc/src/compressPublicKey.ts
+++ b/packages/hw-app-btc/src/compressPublicKey.ts
@@ -1,3 +1,4 @@
+import { Buffer } from "buffer/";
 export function compressPublicKey(publicKey: Buffer): Buffer {
   const prefix = (publicKey[64] & 1) !== 0 ? 0x03 : 0x02;
   const prefixBuffer = Buffer.alloc(1);

--- a/packages/hw-app-btc/src/createTransaction.ts
+++ b/packages/hw-app-btc/src/createTransaction.ts
@@ -1,3 +1,4 @@
+import { Buffer } from "buffer/";
 import { log } from "@ledgerhq/logs";
 import type Transport from "@ledgerhq/hw-transport";
 import { hashPublicKey } from "./hashPublicKey";

--- a/packages/hw-app-btc/src/getTrustedInput.ts
+++ b/packages/hw-app-btc/src/getTrustedInput.ts
@@ -1,3 +1,4 @@
+import { Buffer } from "buffer/";
 import invariant from "invariant";
 import type Transport from "@ledgerhq/hw-transport";
 import type { Transaction } from "./types";

--- a/packages/hw-app-btc/src/getTrustedInputBIP143.ts
+++ b/packages/hw-app-btc/src/getTrustedInputBIP143.ts
@@ -1,3 +1,4 @@
+import { Buffer } from "buffer/";
 import Transport from "@ledgerhq/hw-transport";
 import shajs from "sha.js";
 import type { Transaction } from "./types";

--- a/packages/hw-app-btc/src/newops/accounttype.ts
+++ b/packages/hw-app-btc/src/newops/accounttype.ts
@@ -1,3 +1,4 @@
+import { Buffer } from "buffer/";
 import { crypto } from "bitcoinjs-lib";
 import { pointAddScalar } from "tiny-secp256k1";
 import { BufferWriter } from "../buffertools";

--- a/packages/hw-app-btc/src/newops/appClient.ts
+++ b/packages/hw-app-btc/src/newops/appClient.ts
@@ -1,3 +1,4 @@
+import { Buffer } from "buffer/";
 import Transport from "@ledgerhq/hw-transport";
 import { pathElementsToBuffer } from "../bip32";
 import { PsbtV2 } from "./psbtv2";

--- a/packages/hw-app-btc/src/newops/clientCommands.ts
+++ b/packages/hw-app-btc/src/newops/clientCommands.ts
@@ -1,3 +1,4 @@
+import { Buffer } from "buffer/";
 import { crypto } from "bitcoinjs-lib";
 import { BufferReader } from "../buffertools";
 import { createVarint } from "../varint";

--- a/packages/hw-app-btc/src/newops/merkelizedPsbt.ts
+++ b/packages/hw-app-btc/src/newops/merkelizedPsbt.ts
@@ -1,3 +1,4 @@
+import { Buffer } from "buffer/";
 import { MerkleMap } from "./merkleMap";
 import { PsbtV2 } from "./psbtv2";
 

--- a/packages/hw-app-btc/src/newops/merkle.ts
+++ b/packages/hw-app-btc/src/newops/merkle.ts
@@ -1,3 +1,4 @@
+import { Buffer } from "buffer/";
 import { crypto } from "bitcoinjs-lib";
 
 /**

--- a/packages/hw-app-btc/src/newops/merkleMap.ts
+++ b/packages/hw-app-btc/src/newops/merkleMap.ts
@@ -1,3 +1,4 @@
+import { Buffer } from "buffer/";
 import { createVarint } from "../varint";
 import { hashLeaf, Merkle } from "./merkle";
 

--- a/packages/hw-app-btc/src/newops/policy.ts
+++ b/packages/hw-app-btc/src/newops/policy.ts
@@ -1,3 +1,4 @@
+import { Buffer } from "buffer/";
 import { crypto } from "bitcoinjs-lib";
 import { pathArrayToString } from "../bip32";
 import { BufferWriter } from "../buffertools";

--- a/packages/hw-app-btc/src/newops/psbtExtractor.ts
+++ b/packages/hw-app-btc/src/newops/psbtExtractor.ts
@@ -1,3 +1,4 @@
+import { Buffer } from "buffer/";
 import { BufferWriter } from "../buffertools";
 import { PsbtV2 } from "./psbtv2";
 

--- a/packages/hw-app-btc/src/newops/psbtFinalizer.ts
+++ b/packages/hw-app-btc/src/newops/psbtFinalizer.ts
@@ -1,3 +1,4 @@
+import { Buffer } from "buffer/";
 import { BufferWriter } from "../buffertools";
 import { psbtIn, PsbtV2 } from "./psbtv2";
 

--- a/packages/hw-app-btc/src/newops/psbtv2.ts
+++ b/packages/hw-app-btc/src/newops/psbtv2.ts
@@ -1,3 +1,4 @@
+import { Buffer } from "buffer/";
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 /* eslint-disable @typescript-eslint/explicit-module-boundary-types */
 import {

--- a/packages/hw-app-btc/src/serializeTransaction.ts
+++ b/packages/hw-app-btc/src/serializeTransaction.ts
@@ -1,3 +1,4 @@
+import { Buffer } from "buffer/";
 import type { Transaction } from "./types";
 import { createVarint } from "./varint";
 

--- a/packages/hw-app-btc/src/signMessage.ts
+++ b/packages/hw-app-btc/src/signMessage.ts
@@ -1,3 +1,4 @@
+import { Buffer } from "buffer/";
 import type Transport from "@ledgerhq/hw-transport";
 import bippath from "bip32-path";
 import { MAX_SCRIPT_BLOCK } from "./constants";

--- a/packages/hw-app-btc/src/signP2SHTransaction.ts
+++ b/packages/hw-app-btc/src/signP2SHTransaction.ts
@@ -1,3 +1,4 @@
+import { Buffer } from "buffer/";
 import type Transport from "@ledgerhq/hw-transport";
 import { getTrustedInput } from "./getTrustedInput";
 import { startUntrustedHashTransactionInput } from "./startUntrustedHashTransactionInput";

--- a/packages/hw-app-btc/src/signTransaction.ts
+++ b/packages/hw-app-btc/src/signTransaction.ts
@@ -1,3 +1,4 @@
+import { Buffer } from "buffer/";
 import type Transport from "@ledgerhq/hw-transport";
 import { bip32asBuffer } from "./bip32";
 export function signTransaction(

--- a/packages/hw-app-btc/src/splitTransaction.ts
+++ b/packages/hw-app-btc/src/splitTransaction.ts
@@ -1,3 +1,4 @@
+import { Buffer } from "buffer/";
 import { log } from "@ledgerhq/logs";
 import type { Transaction, TransactionInput, TransactionOutput } from "./types";
 import { getVarint } from "./varint";

--- a/packages/hw-app-btc/src/startUntrustedHashTransactionInput.ts
+++ b/packages/hw-app-btc/src/startUntrustedHashTransactionInput.ts
@@ -1,3 +1,4 @@
+import { Buffer } from "buffer/";
 import type Transport from "@ledgerhq/hw-transport";
 import type { Transaction } from "./types";
 import { createVarint } from "./varint";

--- a/packages/hw-app-btc/src/varint.ts
+++ b/packages/hw-app-btc/src/varint.ts
@@ -1,3 +1,4 @@
+import { Buffer } from "buffer/";
 export function getVarint(data: Buffer, offset: number): [number, number] {
   if (data[offset] < 0xfd) {
     return [data[offset], 1];

--- a/packages/hw-app-cosmos/package.json
+++ b/packages/hw-app-cosmos/package.json
@@ -29,7 +29,8 @@
   "dependencies": {
     "@ledgerhq/errors": "^6.10.0",
     "@ledgerhq/hw-transport": "^6.11.2",
-    "bip32-path": "^0.4.2"
+    "bip32-path": "^0.4.2",
+    "buffer": "^6.0.3"
   },
   "scripts": {
     "clean": "bash ../../script/clean.sh",

--- a/packages/hw-app-cosmos/src/Cosmos.ts
+++ b/packages/hw-app-cosmos/src/Cosmos.ts
@@ -14,6 +14,7 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  ********************************************************************************/
+import { Buffer } from "buffer/";
 import type Transport from "@ledgerhq/hw-transport";
 import BIPPath from "bip32-path";
 import { UserRefusedOnDevice } from "@ledgerhq/errors";

--- a/packages/hw-app-elrond/package.json
+++ b/packages/hw-app-elrond/package.json
@@ -29,7 +29,8 @@
   "dependencies": {
     "@ledgerhq/errors": "^6.10.0",
     "@ledgerhq/hw-transport": "^6.11.2",
-    "bip32-path": "^0.4.2"
+    "bip32-path": "^0.4.2",
+    "buffer": "^6.0.3"
   },
   "scripts": {
     "clean": "bash ../../script/clean.sh",

--- a/packages/hw-app-elrond/src/Elrond.ts
+++ b/packages/hw-app-elrond/src/Elrond.ts
@@ -1,5 +1,6 @@
 //@flow
 
+import { Buffer } from "buffer/";
 import type Transport from "@ledgerhq/hw-transport";
 import BIPPath from "bip32-path";
 

--- a/packages/hw-app-eth/package.json
+++ b/packages/hw-app-eth/package.json
@@ -33,6 +33,7 @@
     "@ledgerhq/logs": "^6.10.0",
     "axios": "^0.24.0",
     "bignumber.js": "^9.0.1",
+    "buffer": "^6.0.3",
     "ethers": "^5.5.1"
   },
   "scripts": {

--- a/packages/hw-app-eth/src/Eth.ts
+++ b/packages/hw-app-eth/src/Eth.ts
@@ -16,6 +16,7 @@
  ********************************************************************************/
 // FIXME drop:
 import { splitPath, foreach } from "./utils";
+import { Buffer } from "buffer/";
 import { log } from "@ledgerhq/logs";
 import { EthAppPleaseEnableContractData } from "@ledgerhq/errors";
 import type Transport from "@ledgerhq/hw-transport";

--- a/packages/hw-app-eth/src/erc20.ts
+++ b/packages/hw-app-eth/src/erc20.ts
@@ -1,3 +1,4 @@
+import { Buffer } from "buffer/";
 import blob from "@ledgerhq/cryptoassets/data/erc20-signatures";
 
 /**

--- a/packages/hw-app-eth/src/nfts.ts
+++ b/packages/hw-app-eth/src/nfts.ts
@@ -1,3 +1,4 @@
+import { Buffer } from "buffer/";
 import axios from "axios";
 import { getLoadConfig } from "./loadConfig";
 import type { LoadConfig } from "./loadConfig";

--- a/packages/hw-app-polkadot/package.json
+++ b/packages/hw-app-polkadot/package.json
@@ -29,7 +29,8 @@
   "dependencies": {
     "@ledgerhq/errors": "^6.10.0",
     "@ledgerhq/hw-transport": "^6.11.2",
-    "bip32-path": "^0.4.2"
+    "bip32-path": "^0.4.2",
+    "buffer": "^6.0.3"
   },
   "scripts": {
     "clean": "bash ../../script/clean.sh",

--- a/packages/hw-app-polkadot/src/Polkadot.ts
+++ b/packages/hw-app-polkadot/src/Polkadot.ts
@@ -15,6 +15,7 @@
  *  limitations under the License.
  ********************************************************************************/
 import type Transport from "@ledgerhq/hw-transport";
+import { Buffer } from "buffer/";
 import BIPPath from "bip32-path";
 import {
   UserRefusedOnDevice,

--- a/packages/hw-app-str/package.json
+++ b/packages/hw-app-str/package.json
@@ -29,6 +29,7 @@
   "dependencies": {
     "@ledgerhq/hw-transport": "^6.11.2",
     "base32.js": "^0.1.0",
+    "buffer": "^6.0.3",
     "sha.js": "^2.3.6",
     "tweetnacl": "^1.0.3"
   },

--- a/packages/hw-app-str/src/Str.ts
+++ b/packages/hw-app-str/src/Str.ts
@@ -14,6 +14,7 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  ********************************************************************************/
+import { Buffer } from "buffer/";
 import type Transport from "@ledgerhq/hw-transport";
 import {
   splitPath,

--- a/packages/hw-app-str/src/utils.ts
+++ b/packages/hw-app-str/src/utils.ts
@@ -14,6 +14,7 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  ********************************************************************************/
+import { Buffer } from "buffer/";
 import base32 from "base32.js";
 import nacl from "tweetnacl";
 import { sha256 } from "sha.js";

--- a/packages/hw-app-tezos/package.json
+++ b/packages/hw-app-tezos/package.json
@@ -30,6 +30,7 @@
     "@ledgerhq/hw-transport": "^6.11.2",
     "blake2b": "^2.1.3",
     "bs58check": "^2.1.2",
+    "buffer": "^6.0.3",
     "invariant": "^2.2.4"
   },
   "scripts": {

--- a/packages/hw-app-tezos/src/Tezos.ts
+++ b/packages/hw-app-tezos/src/Tezos.ts
@@ -14,6 +14,7 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  ********************************************************************************/
+import { Buffer } from "buffer/";
 import invariant from "invariant";
 import bs58check from "bs58check";
 import blake2b from "blake2b";

--- a/packages/hw-app-trx/package.json
+++ b/packages/hw-app-trx/package.json
@@ -28,7 +28,8 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@ledgerhq/errors": "^6.10.0",
-    "@ledgerhq/hw-transport": "^6.11.2"
+    "@ledgerhq/hw-transport": "^6.11.2",
+    "buffer": "^6.0.3"
   },
   "scripts": {
     "clean": "bash ../../script/clean.sh",

--- a/packages/hw-app-trx/src/Trx.ts
+++ b/packages/hw-app-trx/src/Trx.ts
@@ -18,6 +18,7 @@
 import { splitPath, foreach, decodeVarint } from "./utils";
 //import { StatusCodes, TransportStatusError } from "@ledgerhq/errors";
 import type Transport from "@ledgerhq/hw-transport";
+import { Buffer } from "buffer/";
 
 const remapTransactionRelatedErrors = (e) => {
   if (e && e.statusCode === 0x6a80) {

--- a/packages/hw-app-xrp/package.json
+++ b/packages/hw-app-xrp/package.json
@@ -28,7 +28,8 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@ledgerhq/hw-transport": "^6.11.2",
-    "bip32-path": "0.4.2"
+    "bip32-path": "0.4.2",
+    "buffer": "^6.0.3"
   },
   "scripts": {
     "clean": "bash ../../script/clean.sh",

--- a/packages/hw-app-xrp/src/Xrp.ts
+++ b/packages/hw-app-xrp/src/Xrp.ts
@@ -1,3 +1,4 @@
+import { Buffer } from "buffer/";
 import type Transport from "@ledgerhq/hw-transport";
 import BIPPath from "bip32-path";
 /**

--- a/packages/hw-transport-http/package.json
+++ b/packages/hw-transport-http/package.json
@@ -31,6 +31,7 @@
     "@ledgerhq/hw-transport": "^6.11.2",
     "@ledgerhq/logs": "^6.10.0",
     "axios": "^0.24.0",
+    "buffer": "^6.0.3",
     "ws": "7"
   },
   "scripts": {

--- a/packages/hw-transport-http/src/HttpTransport.ts
+++ b/packages/hw-transport-http/src/HttpTransport.ts
@@ -1,3 +1,4 @@
+import { Buffer } from "buffer/";
 import Transport from "@ledgerhq/hw-transport";
 import { TransportError } from "@ledgerhq/errors";
 import axios from "axios";

--- a/packages/hw-transport-http/src/WebSocketTransport.ts
+++ b/packages/hw-transport-http/src/WebSocketTransport.ts
@@ -1,3 +1,4 @@
+import { Buffer } from "buffer/";
 import Transport from "@ledgerhq/hw-transport";
 import { TransportError } from "@ledgerhq/errors";
 import { log } from "@ledgerhq/logs";

--- a/packages/hw-transport-mocker/package.json
+++ b/packages/hw-transport-mocker/package.json
@@ -26,7 +26,8 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@ledgerhq/hw-transport": "^6.11.2",
-    "@ledgerhq/logs": "^6.10.0"
+    "@ledgerhq/logs": "^6.10.0",
+    "buffer": "^6.0.3"
   },
   "scripts": {
     "clean": "bash ../../script/clean.sh",

--- a/packages/hw-transport-mocker/src/RecordStore.ts
+++ b/packages/hw-transport-mocker/src/RecordStore.ts
@@ -1,3 +1,4 @@
+import { Buffer } from "buffer/";
 /**
  * thrown by the RecordStore.fromString parser.
  */

--- a/packages/hw-transport-node-ble/package.json
+++ b/packages/hw-transport-node-ble/package.json
@@ -33,6 +33,7 @@
     "@ledgerhq/errors": "^6.10.0",
     "@ledgerhq/hw-transport": "^6.11.2",
     "@ledgerhq/logs": "^6.10.0",
+    "buffer": "^6.0.3",
     "invariant": "^2.2.4",
     "rxjs": "6"
   },

--- a/packages/hw-transport-node-ble/src/TransportNodeBle.ts
+++ b/packages/hw-transport-node-ble/src/TransportNodeBle.ts
@@ -1,3 +1,4 @@
+import { Buffer } from "buffer/";
 import Transport from "@ledgerhq/hw-transport";
 import type { DeviceModel } from "@ledgerhq/devices";
 import { sendAPDU } from "@ledgerhq/devices/lib/ble/sendAPDU";

--- a/packages/hw-transport-node-ble/src/platform.ts
+++ b/packages/hw-transport-node-ble/src/platform.ts
@@ -1,3 +1,4 @@
+import { Buffer } from "buffer/";
 import noble, { Characteristic, Service } from "@abandonware/noble";
 import { Observable } from "rxjs";
 import { log } from "@ledgerhq/logs";

--- a/packages/hw-transport-node-hid-noevents/package.json
+++ b/packages/hw-transport-node-hid-noevents/package.json
@@ -31,6 +31,7 @@
     "@ledgerhq/errors": "^6.10.0",
     "@ledgerhq/hw-transport": "^6.11.2",
     "@ledgerhq/logs": "^6.10.0",
+    "buffer": "^6.0.3",
     "node-hid": "2.1.1"
   },
   "devDependencies": {

--- a/packages/hw-transport-node-hid-noevents/src/TransportNodeHid.ts
+++ b/packages/hw-transport-node-hid-noevents/src/TransportNodeHid.ts
@@ -1,3 +1,4 @@
+import { Buffer } from "buffer/";
 import HID, { Device } from "node-hid";
 import { log } from "@ledgerhq/logs";
 import Transport, {

--- a/packages/hw-transport-node-speculos/package.json
+++ b/packages/hw-transport-node-speculos/package.json
@@ -31,6 +31,7 @@
     "@ledgerhq/errors": "^6.10.0",
     "@ledgerhq/hw-transport": "^6.11.2",
     "@ledgerhq/logs": "^6.10.0",
+    "buffer": "^6.0.3",
     "rxjs": "6"
   },
   "scripts": {

--- a/packages/hw-transport-node-speculos/src/SpeculosTransport.ts
+++ b/packages/hw-transport-node-speculos/src/SpeculosTransport.ts
@@ -1,3 +1,4 @@
+import { Buffer } from "buffer/";
 import { Subject } from "rxjs";
 import net from "net";
 import Transport from "@ledgerhq/hw-transport";

--- a/packages/hw-transport-web-ble/package.json
+++ b/packages/hw-transport-web-ble/package.json
@@ -31,6 +31,7 @@
     "@ledgerhq/errors": "^6.10.0",
     "@ledgerhq/hw-transport": "^6.11.2",
     "@ledgerhq/logs": "^6.10.0",
+    "buffer": "^6.0.3",
     "rxjs": "6"
   },
   "devDependencies": {

--- a/packages/hw-transport-web-ble/src/TransportWebBLE.ts
+++ b/packages/hw-transport-web-ble/src/TransportWebBLE.ts
@@ -1,4 +1,5 @@
 /* eslint-disable prefer-template */
+import { Buffer } from "buffer/";
 import Transport from "@ledgerhq/hw-transport";
 import {
   DisconnectedDevice,

--- a/packages/hw-transport-web-ble/src/monitorCharacteristic.ts
+++ b/packages/hw-transport-web-ble/src/monitorCharacteristic.ts
@@ -1,3 +1,4 @@
+import { Buffer } from "buffer/";
 import { Observable } from "rxjs";
 import type { Characteristic } from "./types";
 import { log } from "@ledgerhq/logs";

--- a/packages/hw-transport-webhid/package.json
+++ b/packages/hw-transport-webhid/package.json
@@ -29,7 +29,8 @@
     "@ledgerhq/devices": "^6.11.2",
     "@ledgerhq/errors": "^6.10.0",
     "@ledgerhq/hw-transport": "^6.11.2",
-    "@ledgerhq/logs": "^6.10.0"
+    "@ledgerhq/logs": "^6.10.0",
+    "buffer": "^6.0.3"
   },
   "devDependencies": {
     "@types/w3c-web-hid": "^1.0.2"

--- a/packages/hw-transport-webhid/src/TransportWebHID.ts
+++ b/packages/hw-transport-webhid/src/TransportWebHID.ts
@@ -1,3 +1,4 @@
+import { Buffer } from "buffer/";
 import Transport from "@ledgerhq/hw-transport";
 import type {
   Observer,

--- a/packages/hw-transport-webusb/package.json
+++ b/packages/hw-transport-webusb/package.json
@@ -29,7 +29,8 @@
     "@ledgerhq/devices": "^6.11.2",
     "@ledgerhq/errors": "^6.10.0",
     "@ledgerhq/hw-transport": "^6.11.2",
-    "@ledgerhq/logs": "^6.10.0"
+    "@ledgerhq/logs": "^6.10.0",
+    "buffer": "^6.0.3"
   },
   "devDependencies": {
     "@types/w3c-web-usb": "^1.0.5"

--- a/packages/hw-transport-webusb/src/TransportWebUSB.ts
+++ b/packages/hw-transport-webusb/src/TransportWebUSB.ts
@@ -1,3 +1,4 @@
+import { Buffer } from "buffer/";
 import Transport from "@ledgerhq/hw-transport";
 import type {
   Observer,

--- a/packages/hw-transport/package.json
+++ b/packages/hw-transport/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@ledgerhq/devices": "^6.11.2",
     "@ledgerhq/errors": "^6.10.0",
+    "buffer": "^6.0.3",
     "events": "^3.3.0"
   },
   "scripts": {

--- a/packages/hw-transport/src/Transport.ts
+++ b/packages/hw-transport/src/Transport.ts
@@ -1,3 +1,4 @@
+import { Buffer } from "buffer/";
 import EventEmitter from "events";
 import type { DeviceModel } from "@ledgerhq/devices";
 import {

--- a/packages/react-native-hid/package.json
+++ b/packages/react-native-hid/package.json
@@ -33,6 +33,7 @@
     "@ledgerhq/errors": "^6.10.0",
     "@ledgerhq/hw-transport": "^6.11.2",
     "@ledgerhq/logs": "^6.10.0",
+    "buffer": "^6.0.3",
     "rxjs": "6"
   },
   "devDependencies": {

--- a/packages/react-native-hid/src/index.ts
+++ b/packages/react-native-hid/src/index.ts
@@ -1,3 +1,4 @@
+import { Buffer } from "buffer/";
 import { NativeModules, DeviceEventEmitter } from "react-native";
 import { ledgerUSBVendorId, identifyUSBProductId } from "@ledgerhq/devices";
 import type { DeviceModel } from "@ledgerhq/devices";

--- a/packages/react-native-hw-transport-ble/package.json
+++ b/packages/react-native-hw-transport-ble/package.json
@@ -29,6 +29,7 @@
     "@ledgerhq/errors": "^6.10.0",
     "@ledgerhq/hw-transport": "^6.11.2",
     "@ledgerhq/logs": "^6.10.0",
+    "buffer": "^6.0.3",
     "invariant": "^2.2.4",
     "react-native-ble-plx": "2.0.3",
     "rxjs": "6",

--- a/packages/react-native-hw-transport-ble/src/BleTransport.ts
+++ b/packages/react-native-hw-transport-ble/src/BleTransport.ts
@@ -1,4 +1,5 @@
 /* eslint-disable prefer-template */
+import { Buffer } from "buffer/";
 import Transport from "@ledgerhq/hw-transport";
 import {
   BleManager,

--- a/packages/react-native-hw-transport-ble/src/monitorCharacteristic.ts
+++ b/packages/react-native-hw-transport-ble/src/monitorCharacteristic.ts
@@ -1,3 +1,4 @@
+import { Buffer } from "buffer/";
 import { Observable } from "rxjs";
 import { TransportError } from "@ledgerhq/errors";
 import type { Characteristic } from "./types";

--- a/yarn.lock
+++ b/yarn.lock
@@ -2671,7 +2671,7 @@ base32.js@^0.1.0:
   resolved "https://registry.yarnpkg.com/base32.js/-/base32.js-0.1.0.tgz#b582dec693c2f11e893cf064ee6ac5b6131a2202"
   integrity sha1-tYLexpPC8R6JPPBk7mrFthMaIgI=
 
-base64-js@^1.0.2:
+base64-js@^1.0.2, base64-js@^1.3.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
   integrity sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==
@@ -3066,6 +3066,14 @@ buffer-xor@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/buffer-xor/-/buffer-xor-1.0.3.tgz#26e61ed1422fb70dd42e6e36729ed51d855fe8d9"
   integrity sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk=
+
+buffer@^6.0.3:
+  version "6.0.3"
+  resolved "https://registry.yarnpkg.com/buffer/-/buffer-6.0.3.tgz#2ace578459cc8fbe2a70aaa8f52ee63b6a74c6c6"
+  integrity sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==
+  dependencies:
+    base64-js "^1.3.1"
+    ieee754 "^1.2.1"
 
 buffer@~5.2.1:
   version "5.2.1"
@@ -5706,6 +5714,11 @@ ieee754@^1.1.4:
   version "1.1.13"
   resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.1.13.tgz#ec168558e95aa181fd87d37f55c32bbcb6708b84"
   integrity sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==
+
+ieee754@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.2.1.tgz#8eb7a10a63fff25d15a57b001586d177d1b0d352"
+  integrity sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==
 
 iferr@^0.1.5:
   version "0.1.5"


### PR DESCRIPTION
> Resolves https://github.com/LedgerHQ/ledgerjs/issues/734

This uses the `Buffer` from [feross/buffer](https://github.com/feross/buffer) because it is compatible with browsers and node. This means clients won't need any extra polyfills or configurations on their end to run ledger packages inside of browsers.