### PR TITLE
Fix wrong bytestring parsing in NFT informations + missing awaits

### DIFF
--- a/packages/hw-app-eth/src/services/ledger/index.ts
+++ b/packages/hw-app-eth/src/services/ledger/index.ts
@@ -108,14 +108,14 @@ const ledgerService: LedgerEthTransactionService = {
                 }
                 return value[seg];
               }, args);
-              provideForContract(address);
+              await provideForContract(address);
             }
           }
         } else {
           log("ethereum", "no infos for selector " + selector);
         }
       }
-      provideForContract(decodedTx.to);
+      await provideForContract(decodedTx.to);
     }
 
     return resolution;


### PR DESCRIPTION
- Fixing the wrong parsing inside of the Eth app. (No impact at all since it's purely for logging purposes)
- Fixing missing awaits leading to NFT Infos not getting fetched and fed to the nano. 

Spec for the bytestring parsing: https://ledgerhq.atlassian.net/wiki/spaces/WALLETCO/pages/3269984297/NFT-1+NFT+Backend+design#NFT-Metadata-BLOB