### PR TITLE
Change peercoin explorer url

### DIFF
--- a/packages/cryptoassets/src/currencies.ts
+++ b/packages/cryptoassets/src/currencies.ts
@@ -1865,8 +1865,8 @@ const cryptocurrenciesById: Record<string, CryptoCurrency> = {
     ],
     explorerViews: [
       {
-        tx: "https://explorer.peercoin.net/tx/$hash",
-        address: "https://explorer.peercoin.net/address/$address",
+        tx: "https://blockbook.peercoin.net/tx/$hash",
+        address: "https://blockbook.peercoin.net/address/$address",
       },
     ],
   },


### PR DESCRIPTION
Suggested by https://github.com/LedgerHQ/ledgerjs/pull/702/files
They are migrating peercoin explorer url