### PR TITLE
[fix] allow asset importers to define which content they can load

### DIFF
--- a/script/crypto-assets-importer/importers/ethereum-plugins.js
+++ b/script/crypto-assets-importer/importers/ethereum-plugins.js
@@ -1,4 +1,5 @@
 const path = require("path");
+const fs = require('fs');
 const isEqual = require("lodash/isEqual");
 const { readFileJSON } = require("../utils");
 
@@ -33,6 +34,11 @@ module.exports = {
   },
 
   outputTemplate: (data) => JSON.stringify(data, null, 2),
+
+  shouldLoad: ({ folder, id }) => {
+    const b2cFilePath = path.join(folder, id, "b2c.json");
+    return fs.existsSync(b2cFilePath);
+  },
 
   loader: async ({ signatureFolder, folder, id }) => {
     const [signatures, bare] = await Promise.all([

--- a/script/crypto-assets-importer/index.js
+++ b/script/crypto-assets-importer/index.js
@@ -34,9 +34,10 @@ axios
           const folder = path.join(inputFolder, "assets", p);
           const signatureFolder = path.join(inputFolder, "signatures/prod/", p);
           const items = fs.readdirSync(folder);
+          const shouldLoad = ((id) => imp.shouldLoad ? imp.shouldLoad({ folder, id }) : !id.endsWith(".json"));
           return promiseAllBatched(
             50,
-            items.sort().filter((a) => !a.endsWith(".json")),
+            items.sort().filter(shouldLoad),
             (id) =>
               Promise.resolve()
                 .then(() => imp.loader({ signatureFolder, folder, id }))


### PR DESCRIPTION
Ethereum plugins as defined in https://github.com/LedgerHQ/ledger-asset-dapps/ don't necessarily have a `b2c.json` file anymore, in which case they should just be ignored by the Live for now as they are only defined for B2B.

The `ethereum-plugins.js` importer fails to load the plugin in question, and raises an exception that is properly caught and logged by the main script.
However the error can be scary, and does not need to be raised in this case, so I added the notion of `shouldLoad` which allows importers to decide whether to skip a file or not. This notion already existed implicitly (checking if the file is a JSON), and I have simply extended it.

Let me know if this implementation suits you =]