### PR TITLE
LL 8968 - Add strict mode to prevent blind signing in live

### DIFF
--- a/packages/hw-app-eth/src/Eth.ts
+++ b/packages/hw-app-eth/src/Eth.ts
@@ -20,6 +20,7 @@ import { BigNumber } from "bignumber.js";
 import { decodeTxInfo } from "./utils";
 // NB: these are temporary import for the deprecated fallback mechanism
 import { LedgerEthTransactionResolution, LoadConfig } from "./services/types";
+import { defaultLoadConfig } from "./services/ledger/loadConfig";
 import ledgerService from "./services/ledger";
 import {
   EthAppNftNotSupported,
@@ -76,6 +77,7 @@ const remapTransactionRelatedErrors = (e) => {
 
   return e;
 };
+
 /**
  * Ethereum API
  *
@@ -86,10 +88,13 @@ const remapTransactionRelatedErrors = (e) => {
 
 export default class Eth {
   transport: Transport;
-  loadConfig: LoadConfig;
+  loadConfig: LoadConfig = {};
 
   setLoadConfig(loadConfig: LoadConfig): void {
-    this.loadConfig = loadConfig;
+    this.loadConfig = {
+      ...defaultLoadConfig,
+      ...loadConfig,
+    };
   }
 
   constructor(
@@ -97,8 +102,8 @@ export default class Eth {
     scrambleKey = "w0w",
     loadConfig: LoadConfig = {}
   ) {
+    this.setLoadConfig(loadConfig);
     this.transport = transport;
-    this.loadConfig = loadConfig;
     transport.decorateAppAPIMethods(
       this,
       [

--- a/packages/hw-app-eth/src/Eth.ts
+++ b/packages/hw-app-eth/src/Eth.ts
@@ -237,18 +237,28 @@ export default class Eth {
     // provide to the device resolved information to make it clear sign the signature
     if (resolution) {
       for (const plugin of resolution.plugin) {
-        await setPlugin(this.transport, plugin);
+        await setPlugin(this.transport, plugin, this.loadConfig);
       }
       for (const { payload, signature } of resolution.externalPlugin) {
-        await setExternalPlugin(this.transport, payload, signature);
+        await setExternalPlugin(
+          this.transport,
+          payload,
+          signature,
+          this.loadConfig
+        );
       }
       for (const nft of resolution.nfts) {
-        await provideNFTInformation(this.transport, Buffer.from(nft, "hex"));
+        await provideNFTInformation(
+          this.transport,
+          Buffer.from(nft, "hex"),
+          this.loadConfig
+        );
       }
       for (const data of resolution.erc20Tokens) {
         await provideERC20TokenInformation(
           this.transport,
-          Buffer.from(data, "hex")
+          Buffer.from(data, "hex"),
+          this.loadConfig
         );
       }
     }
@@ -1142,7 +1152,7 @@ export default class Eth {
     console.warn(
       "hw-app-eth: eth.provideERC20TokenInformation is deprecated. signTransaction solves this for you when providing it in `resolution`."
     );
-    return provideERC20TokenInformation(this.transport, data);
+    return provideERC20TokenInformation(this.transport, data, this.loadConfig);
   }
 
   setExternalPlugin(
@@ -1153,14 +1163,19 @@ export default class Eth {
     console.warn(
       "hw-app-eth: eth.setExternalPlugin is deprecated. signTransaction solves this for you when providing it in `resolution`."
     );
-    return setExternalPlugin(this.transport, pluginName, selector);
+    return setExternalPlugin(
+      this.transport,
+      pluginName,
+      selector,
+      this.loadConfig
+    );
   }
 
   setPlugin(data: string): Promise<boolean> {
     console.warn(
       "hw-app-eth: eth.setPlugin is deprecated. signTransaction solves this for you when providing it in `resolution`."
     );
-    return setPlugin(this.transport, data);
+    return setPlugin(this.transport, data, this.loadConfig);
   }
 }
 
@@ -1168,7 +1183,8 @@ export default class Eth {
 
 function provideERC20TokenInformation(
   transport: Transport,
-  data: Buffer
+  data: Buffer,
+  loadConfig: LoadConfig
 ): Promise<boolean> {
   return transport.send(0xe0, 0x0a, 0x00, 0x00, data).then(
     () => true,
@@ -1185,7 +1201,8 @@ function provideERC20TokenInformation(
 
 function provideNFTInformation(
   transport: Transport,
-  data: Buffer
+  data: Buffer,
+  loadConfig: LoadConfig
 ): Promise<boolean> {
   return transport.send(0xe0, 0x14, 0x00, 0x00, data).then(
     () => true,
@@ -1206,7 +1223,8 @@ function provideNFTInformation(
 function setExternalPlugin(
   transport: Transport,
   payload: string,
-  signature: string
+  signature: string,
+  loadConfig: LoadConfig
 ): Promise<boolean> {
   const payloadBuffer = Buffer.from(payload, "hex");
   const signatureBuffer = Buffer.from(signature, "hex");
@@ -1229,7 +1247,12 @@ function setExternalPlugin(
   );
 }
 
-function setPlugin(transport: Transport, data: string): Promise<boolean> {
+function setPlugin(
+  transport: Transport,
+  data: string,
+  loadConfig: LoadConfig
+): Promise<boolean> {
+  const { strictMode } = loadConfig;
   const buffer = Buffer.from(data, "hex");
   return transport.send(0xe0, 0x16, 0x00, 0x00, buffer).then(
     () => true,

--- a/packages/hw-app-eth/src/services/ledger/contracts.ts
+++ b/packages/hw-app-eth/src/services/ledger/contracts.ts
@@ -1,5 +1,4 @@
 import axios from "axios";
-import { getLoadConfig } from "./loadConfig";
 import type { LoadConfig } from "../types";
 import { log } from "@ledgerhq/logs";
 
@@ -18,9 +17,9 @@ export const loadInfosForContractMethod = async (
   contractAddress: string,
   selector: string,
   chainId: number,
-  userLoadConfig: LoadConfig
+  loadConfig: LoadConfig
 ): Promise<ContractMethod | undefined> => {
-  const { pluginBaseURL, extraPlugins } = getLoadConfig(userLoadConfig);
+  const { pluginBaseURL, extraPlugins } = loadConfig;
 
   let data = {};
 

--- a/packages/hw-app-eth/src/services/ledger/loadConfig.ts
+++ b/packages/hw-app-eth/src/services/ledger/loadConfig.ts
@@ -1,6 +1,7 @@
 import type { LoadConfig } from "../types";
 
-const defaultLoadConfig = {
+export const defaultLoadConfig: LoadConfig = {
+  strictMode: false,
   nftExplorerBaseURL: null, // set a value when an official production endpoint is released
   pluginBaseURL: "https://cdn.live.ledger.com",
   extraPlugins: null,

--- a/packages/hw-app-eth/src/services/ledger/loadConfig.ts
+++ b/packages/hw-app-eth/src/services/ledger/loadConfig.ts
@@ -6,10 +6,3 @@ export const defaultLoadConfig: LoadConfig = {
   pluginBaseURL: "https://cdn.live.ledger.com",
   extraPlugins: null,
 };
-
-export function getLoadConfig(userLoadConfig?: LoadConfig): LoadConfig {
-  return {
-    ...defaultLoadConfig,
-    ...userLoadConfig,
-  };
-}

--- a/packages/hw-app-eth/src/services/ledger/nfts.ts
+++ b/packages/hw-app-eth/src/services/ledger/nfts.ts
@@ -1,5 +1,4 @@
 import axios from "axios";
-import { getLoadConfig } from "./loadConfig";
 import type { LoadConfig } from "../types";
 
 type NftInfo = {
@@ -21,9 +20,9 @@ function axiosErrorHandling(e) {
 export const getNFTInfo = async (
   contractAddress: string,
   chainId: number,
-  userLoadConfig: LoadConfig
+  loadConfig: LoadConfig
 ): Promise<NftInfo | undefined> => {
-  const { nftExplorerBaseURL } = getLoadConfig(userLoadConfig);
+  const { nftExplorerBaseURL } = loadConfig;
   if (!nftExplorerBaseURL) return;
   const url = `${nftExplorerBaseURL}/${chainId}/contracts/${contractAddress}`;
   const response = await axios
@@ -55,9 +54,9 @@ export const loadNftPlugin = async (
   contractAddress: string,
   selector: string,
   chainId: number,
-  userLoadConfig: LoadConfig
+  loadConfig: LoadConfig
 ): Promise<string | undefined> => {
-  const { nftExplorerBaseURL } = getLoadConfig(userLoadConfig);
+  const { nftExplorerBaseURL } = loadConfig;
   if (!nftExplorerBaseURL) return;
   const url = `${nftExplorerBaseURL}/${chainId}/contracts/${contractAddress}/plugin-selector/${selector}`;
 

--- a/packages/hw-app-eth/src/services/types.ts
+++ b/packages/hw-app-eth/src/services/types.ts
@@ -10,6 +10,9 @@ export type LedgerEthTransactionResolution = {
 };
 
 export type LoadConfig = {
+  // if set to true, the strict mode will throw errors on any case of blind signing,
+  // preventing the transaction completely
+  strictMode?: boolean;
   nftExplorerBaseURL?: string | null;
   // example of payload https://cdn.live.ledger.com/plugins/ethereum/1.json
   // fetch against an api (base url is an api that hosts /plugins/ethereum/${chainId}.json )


### PR DESCRIPTION
This PR add the notion of `strictMode` for the `Eth` class in order to throw errors on specific cases related to transaction resolution.

[LL-8968](https://ledgerhq.atlassian.net/browse/LL-8968)