### PR TITLE
chore: add missing @helium/proto dependency

### DIFF
--- a/packages/hw-app-helium/package.json
+++ b/packages/hw-app-helium/package.json
@@ -28,6 +28,7 @@
     "license": "Apache-2.0",
     "dependencies": {
         "@helium/crypto": "^3.45.0",
+        "@helium/proto": "^1.5.0",
         "@helium/transactions": "^3.62.0",
         "@ledgerhq/errors": "^6.10.0",
         "@ledgerhq/hw-transport": "^6.11.2",


### PR DESCRIPTION
Package `@ledgerhq/hw-app-helium` added with [this PR](https://github.com/LedgerHQ/ledgerjs/pull/768) has a missing dependency. 

`@helium/proto` itself is technically a dependency of other `@helium/…` packages but it is not good practice to directly import transitive dependencies like this (and the build will fail with `pnpm` since it is stricter than `yarn`).

```
src/Helium.ts(12,19): error TS2307: Cannot find module '@helium/proto' or its corresponding type declarations.
```

<img width="272" alt="Capture d’écran 2022-01-31 à 14 58 02" src="https://user-images.githubusercontent.com/3428394/151809070-69f0d9c3-797a-48fa-998d-284954d7d166.png">
<img width="329" alt="Capture d’écran 2022-01-31 à 14 58 09" src="https://user-images.githubusercontent.com/3428394/151809073-e86204e9-08f6-42b5-9cbd-f9fcb6e5d0b8.png">
