### PR TITLE
LL-8941 Conditionally auto disconnect the node-hid-singleton

### DIFF
--- a/packages/hw-transport-node-hid-singleton/README.md
+++ b/packages/hw-transport-node-hid-singleton/README.md
@@ -17,10 +17,13 @@ Allows to communicate with Ledger Hardware Wallets.
 
 *   [TransportNodeHidSingleton](#transportnodehidsingleton)
     *   [Examples](#examples)
+    *   [exchange](#exchange)
+        *   [Parameters](#parameters)
     *   [isSupported](#issupported)
     *   [list](#list)
     *   [listen](#listen)
-        *   [Parameters](#parameters)
+        *   [Parameters](#parameters-1)
+    *   [autoDisconnect](#autodisconnect)
     *   [disconnect](#disconnect)
     *   [open](#open)
 
@@ -38,6 +41,16 @@ import TransportNodeHid from "@ledgerhq/hw-transport-node-hid-singleton";
 TransportNodeHid.create().then(transport => ...)
 ```
 
+#### exchange
+
+Exchange with the device using APDU protocol.
+
+##### Parameters
+
+*   `apdu` **[Buffer](https://nodejs.org/api/buffer.html)** 
+
+Returns **[Promise](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)<[Buffer](https://nodejs.org/api/buffer.html)>** a promise of apdu response
+
 #### isSupported
 
 #### list
@@ -49,6 +62,12 @@ TransportNodeHid.create().then(transport => ...)
 *   `observer` **Observer\<DescriptorEvent\<any>>** 
 
 Returns **Subscription** 
+
+#### autoDisconnect
+
+convenience wrapper for auto-disconnect logic
+
+Returns **void** 
 
 #### disconnect
 

--- a/packages/hw-transport-node-hid-singleton/src/TransportNodeHid.ts
+++ b/packages/hw-transport-node-hid-singleton/src/TransportNodeHid.ts
@@ -12,6 +12,23 @@ import { identifyUSBProductId } from "@ledgerhq/devices";
 import { CantOpenDevice } from "@ledgerhq/errors";
 import { listenDevices } from "./listenDevices";
 let transportInstance;
+
+const DISCONNECT_TIMEOUT = 5000;
+let disconnectTimeout;
+const clearDisconnectTimeout = () => {
+  if (disconnectTimeout) {
+    clearTimeout(disconnectTimeout);
+  }
+};
+
+const setDisconnectTimeout = () => {
+  clearDisconnectTimeout();
+  disconnectTimeout = setTimeout(
+    () => TransportNodeHidSingleton.autoDisconnect(),
+    DISCONNECT_TIMEOUT
+  );
+};
+
 /**
  * node-hid Transport implementation
  * @example
@@ -21,6 +38,7 @@ let transportInstance;
  */
 
 export default class TransportNodeHidSingleton extends TransportNodeHidNoEvents {
+  preventAutoDisconnect = false;
   /**
    *
    */
@@ -89,6 +107,20 @@ export default class TransportNodeHidSingleton extends TransportNodeHidNoEvents 
   };
 
   /**
+   * convenience wrapper for auto-disconnect logic
+   */
+  static async autoDisconnect(): void {
+    if (transportInstance && !transportInstance.preventAutoDisconnect) {
+      log("hid-verbose", "triggering auto disconnect");
+      TransportNodeHidSingleton.disconnect();
+    } else if (transportInstance) {
+      // If we have disabled the auto-disconnect, try again in DISCONNECT_TIMEOUT
+      clearDisconnectTimeout();
+      setDisconnectTimeout();
+    }
+  }
+
+  /**
    * globally disconnect the transport singleton
    */
   static async disconnect() {
@@ -97,12 +129,14 @@ export default class TransportNodeHidSingleton extends TransportNodeHidNoEvents 
       transportInstance.emit("disconnect");
       transportInstance = null;
     }
+    clearDisconnectTimeout();
   }
 
   /**
    * if path="" is not provided, the library will take the first device
    */
   static open(): Promise<TransportNodeHidSingleton> {
+    clearDisconnectTimeout();
     return Promise.resolve().then(() => {
       if (transportInstance) {
         log("hid-verbose", "reusing opened transport instance");
@@ -138,8 +172,26 @@ export default class TransportNodeHidSingleton extends TransportNodeHidNoEvents 
     });
   }
 
-  close() {
-    // intentionally, a close will not effectively close the hid connection
+  setAllowAutoDisconnect(allow: boolean): void {
+    this.preventAutoDisconnect = !allow;
+  }
+
+  /**
+   * Exchange with the device using APDU protocol.
+   * @param apdu
+   * @returns a promise of apdu response
+   */
+  async exchange(apdu: Buffer): Promise<Buffer> {
+    clearDisconnectTimeout();
+    const result = await super.exchange(apdu);
+    setDisconnectTimeout();
+    return result;
+  }
+
+  close(): Promise<void> {
+    // intentionally, a close will not effectively close the hid connection but
+    // will allow an auto-disconnection after some inactivity
+    this.preventAutoDisconnect = false;
     return Promise.resolve();
   }
 }


### PR DESCRIPTION
Here's the second attempt at getting a automatic release of the node-hid-singleton. After the talk we had the other day @gre I think that by exposing this method `setAllowAutoDisconnect` at the transport level and allowing it to override the auto-disconnect (basically re-scheduling it again) will allow us to call `transport.setAllowAutoDisconnect(false)` at the begining of the `withDevice` implementation on `hw/deviceAccess` from [live-common](https://github.com/LedgerHQ/ledger-live-common/blob/master/src/hw/deviceAccess.ts#L108) and unsetting the flag on the `onClose` for the transport, we essentially bypass the problem we have of long running tasks inside a `withDevice` instance.

What do you think?