### PR TITLE
[@ledgerHQ/hw-app-helium] switch to use @helium/address

### DIFF
--- a/packages/hw-app-helium/package.json
+++ b/packages/hw-app-helium/package.json
@@ -27,7 +27,7 @@
     "types": "lib/Helium.d.ts",
     "license": "Apache-2.0",
     "dependencies": {
-        "@helium/crypto": "^3.45.0",
+        "@helium/address": "^4.0.0",
         "@helium/proto": "^1.5.0",
         "@helium/transactions": "^3.62.0",
         "@ledgerhq/errors": "^6.10.0",

--- a/packages/hw-app-helium/src/Helium.ts
+++ b/packages/hw-app-helium/src/Helium.ts
@@ -1,6 +1,6 @@
 import Transport from "@ledgerhq/hw-transport";
 import { StatusCodes } from "@ledgerhq/errors";
-import { Address } from "@helium/crypto";
+import Address from "@helium/address";
 import {
   PaymentV2,
   SecurityExchangeV1,

--- a/packages/hw-app-helium/src/serialization.ts
+++ b/packages/hw-app-helium/src/serialization.ts
@@ -1,4 +1,4 @@
-import { Address } from "@helium/crypto";
+import Address from "@helium/address";
 import {
   PaymentV2,
   StakeValidatorV1,

--- a/packages/hw-app-helium/tests/Helium.test.ts
+++ b/packages/hw-app-helium/tests/Helium.test.ts
@@ -5,7 +5,7 @@ import {
   TransferValidatorStakeV1,
   UnstakeValidatorV1,
 } from "@helium/transactions";
-import { Address } from "@helium/crypto";
+import Address from "@helium/address";
 import {
   openTransportReplayer,
   RecordStore,

--- a/yarn.lock
+++ b/yarn.lock
@@ -627,7 +627,15 @@
     unique-filename "^1.1.1"
     which "^1.3.1"
 
-"@helium/crypto@^3.45.0", "@helium/crypto@^3.60.0":
+"@helium/address@^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@helium/address/-/address-4.0.0.tgz#041c075bf6b750e52cdbee4a45950bfbf42e085a"
+  integrity sha512-rkQNI98lifSTc2I9GfVYRukThUCY+9ba77EadhaiFI9SHOJ/lSFp93zHOHkcyr1AI8DpKgZQGx19hqFOL7QpcA==
+  dependencies:
+    bs58 "4.0.1"
+    js-sha256 "^0.9.0"
+
+"@helium/crypto@^3.60.0":
   version "3.60.0"
   resolved "https://registry.yarnpkg.com/@helium/crypto/-/crypto-3.60.0.tgz#58be74745d0c7cc3198481dc69f5530393fc7287"
   integrity sha512-zvDshfSv9wv0PAmmKvZPFP9pnNmR6Q7ZAy+WuGpCD3AxuWv9fiODgKATVuTMhV/QXkkxI+5t8TbGUjTOxsXAmA==
@@ -2937,7 +2945,7 @@ bs-logger@0.x:
   dependencies:
     fast-json-stable-stringify "2.x"
 
-bs58@^4.0.0, bs58@^4.0.1:
+bs58@4.0.1, bs58@^4.0.0, bs58@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/bs58/-/bs58-4.0.1.tgz#be161e76c354f6f788ae4071f63f34e8c4f0a42a"
   integrity sha1-vhYedsNU9veIrkBx9j806MTwpCo=
@@ -6638,6 +6646,11 @@ js-levenshtein@^1.1.6:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/js-levenshtein/-/js-levenshtein-1.1.6.tgz#c6cee58eb3550372df8deb85fad5ce66ce01d59d"
   integrity sha512-X2BB11YZtrRqY4EnQcLX5Rh373zbK4alC1FW7D7MBhL2gtcC17cTnr6DmfHZeS0s2rTHjUTMMHfG7gO8SSdw+g==
+
+js-sha256@^0.9.0:
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/js-sha256/-/js-sha256-0.9.0.tgz#0b89ac166583e91ef9123644bd3c5334ce9d0966"
+  integrity sha512-sga3MHh9sgQN2+pJ9VYZ+1LPwXOxuBJBA5nrR5/ofPfuiJBE2hnjsaN8se8JznOmGLN2p49Pe5U/ttafcs/apA==
 
 js-sha3@0.8.0:
   version "0.8.0"


### PR DESCRIPTION
This uses a simplified, common `@helium/address` package which has been extracted from our two crypto packages, `@helium/crypto` and `@helium/crypto-react-native`. This will allow `@ledgerHQ/hw-app-helium` to be used on both react native and nodejs. Currently it will only work on nodejs.