### PR TITLE
[@ledgerHQ/hw-app-helium] fix bug in verify address mode

### DIFF
--- a/packages/hw-app-helium/src/Helium.ts
+++ b/packages/hw-app-helium/src/Helium.ts
@@ -116,7 +116,7 @@ export default class Helium {
       pathBuffer
     );
 
-    const address = Address.fromBin(addressBuffer.slice(1));
+    const address = Address.fromBin(addressBuffer.slice(1, 34));
 
     return {
       index: addressBuffer.slice(0, 1)[0],


### PR DESCRIPTION
This fixes a bug where an invalid address was being created from the return value of `getAddress` where `display` was `true`. The issue is that the buffer from the device returns extra data after the public key when the verify flag is true. We know the public key will always be 32 bytes, so we slice out that exact amount. The extra data will be removed in a future firmware release, but this will fix it in the current version and remain future proof