### PR TITLE
Add Osmosis currency definition

### DIFF
--- a/packages/cryptoassets/src/currencies.ts
+++ b/packages/cryptoassets/src/currencies.ts
@@ -2504,6 +2504,35 @@ const cryptocurrenciesById: Record<string, CryptoCurrency> = {
       },
     ],
   },
+  osmosis: {
+    type: "CryptoCurrency",
+    id: "osmo",
+    coinType: 118,
+    name: "Osmosis",
+    managerAppName: "Cosmos",
+    ticker: "OSMO",
+    scheme: "osmo",
+    color: "#493c9b",
+    family: "osmosis",
+    units: [
+      {
+        name: "Osmosis",
+        code: "OSMO",
+        magnitude: 6,
+      },
+      {
+        name: "Micro-OSMO",
+        code: "uosmo",
+        magnitude: 0,
+      },
+    ],
+    explorerViews: [
+      {
+        tx: "https://www.mintscan.io/osmosis/txs/$hash",
+        address: "https://www.mintscan.io/osmosis/account/$address",
+      },
+    ],
+  },
   tezos: {
     type: "CryptoCurrency",
     id: "tezos",


### PR DESCRIPTION
This PR adds the Osmosis definition to currencies.ts in the @ledgerhq/cryptoassets package. It is used in the upcoming Live Common and Live Desktop PRs to ultimately allow Ledger Live Desktop to import, sync & send Osmosis assets.