### PR TITLE
LIVE-545 Add Invalid channel to the list of disconnected errors

### DIFF
--- a/packages/react-native-hid/src/index.ts
+++ b/packages/react-native-hid/src/index.ts
@@ -17,7 +17,7 @@ type DeviceObj = {
 const disconnectedErrors = [
   "I/O error",
   "Attempt to invoke virtual method 'int android.hardware.usb.UsbDevice.getDeviceClass()' on a null object reference",
-  "Invalid channel"
+  "Invalid channel",
 ];
 
 const listLedgerDevices = async () => {

--- a/packages/react-native-hid/src/index.ts
+++ b/packages/react-native-hid/src/index.ts
@@ -17,6 +17,7 @@ type DeviceObj = {
 const disconnectedErrors = [
   "I/O error",
   "Attempt to invoke virtual method 'int android.hardware.usb.UsbDevice.getDeviceClass()' on a null object reference",
+  "Invalid channel"
 ];
 
 const listLedgerDevices = async () => {


### PR DESCRIPTION
A common error that might happen when a device is abruptly disconnected from USB during an exchange is the "Invalid channel" error.

Defined at android/src/main/java/com/ledgerwallet/hid/LedgerHelper.java at lines 82, 85, 54 and 57.

This PR adds this error to a list of errors that get caught and mapped to a DisconnectedDevice type of error. This provides a cleaner wording for the user explaining that the device was disconnected and the user should retry the operation. Without it, the error that is displayed to the user states only "Invalid channel" which doesn't mean much and isn't even translated.

PS.: For now, a manual mapping was added in LLM in https://github.com/LedgerHQ/ledger-live-mobile/pull/2432 . After this is merged and all upgrades are done to LLC and then LLM, that manual mapping can be removed.